### PR TITLE
fix: adding default peer with new realm now is not crushing application

### DIFF
--- a/src/diameter/node/node.py
+++ b/src/diameter/node/node.py
@@ -1191,7 +1191,9 @@ class Node:
             persistent=is_persistent)
         self.peers[uri.fqdn] = peer
         if is_default:
-            self._peer_routes.get(realm_name, {}).get("_default", []).append(peer)
+            self._peer_routes.setdefault(peer.realm_name, {})
+            peers = self._peer_routes[peer.realm_name].setdefault("_default", [])
+            peers.append(peer)
 
         return peer
 

--- a/src/diameter/node/node.py
+++ b/src/diameter/node/node.py
@@ -1191,7 +1191,7 @@ class Node:
             persistent=is_persistent)
         self.peers[uri.fqdn] = peer
         if is_default:
-            self._peer_routes[realm_name]["_default"].append(peer)
+            self._peer_routes.get(realm_name, {}).get("_default", []).append(peer)
 
         return peer
 


### PR DESCRIPTION
When `node.add_peer(..., is_default=True)` with new realm or before `node.add_application(app, [peer])`, application was crashing because no such key in _peer_routes (`self._peer_routes[realm_name]`).

Fixed by using dict.get method on self._peer_routes and further