### PR TITLE
Fix Address AVP decoding for unknown address types

### DIFF
--- a/src/diameter/message/avp/avp.py
+++ b/src/diameter/message/avp/avp.py
@@ -397,7 +397,8 @@ class AvpAddress(Avp):
         elif addr_type == 8:
             return addr_type, self.payload[2:].decode("utf-8")
         else:
-            return addr_type, self.payload[2:].decode("utf-8")
+            # Instead of trying to decode unknown formats, just return hex string
+            return addr_type, self.payload[2:].hex()
 
     @value.setter
     def value(self, new_value: str):


### PR DESCRIPTION
### Summary

This PR fixes an issue in the `AvpAddress` class where unknown address types are decoded as UTF-8 strings, which can raise a `UnicodeDecodeError` if the payload is not valid UTF-8.

According to [RFC 3588](https://datatracker.ietf.org/doc/html/rfc3588#section-4.3), the Address AVP contains an address family and a binary representation of the address. The implementation already supports types 1 (IPv4), 2 (IPv6), and 8 (E.164). However, when the address type is unknown, the fallback tries to decode the raw bytes as UTF-8, which is unsafe.

### Fix

Since this method is only used for string conversion (e.g., `__str__()` and `dump()`), the fix simply avoids exceptions by returning the binary address as a hexadecimal string instead of decoding it.

### Before

```python
else:
    return addr_type, self.payload[2:].decode("utf-8")  # may raise UnicodeDecodeError
```

### After

```python
else:
    return addr_type, self.payload[2:].hex()  # safe fallback for unknown types
```

### Example crash

```python
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte
```

### Benefits

- Prevents crashes when printing or dumping messages with unknown address types.
- Ensures AVPs are always printable, even if their format is not recognized.
- Maintains safe and readable output for debugging purposes.

---

Since this method is only used for display purposes, there's no impact on parsing logic or runtime safety.
