### PR TITLE
Add an implementation for Cx/Dx interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The `diameter` package provides tools for:
 
 ## Supported applications
 
-The diameter stack has inbuilt support for Diameter Base, *Gy*, *Rf*, *Ro* and
-*Sy* applications and a generic implementation of application types that allows
-working even with unsupported application types.
+The diameter stack has inbuilt support for Diameter Base, *Gy*, *Rf*, *Ro*, 
+*Sy*, *Cx* and *Dx* applications and a generic implementation of application 
+types that allows working even with unsupported application types.
 
 ## Supported diameter application commands
 
@@ -80,5 +80,14 @@ application message types:
 
  * Spending-Limit
  * Spending-Status-Notification
+
+*Diameter Cx and Dx interfaces* `3GPP TS 29.229`
+
+ * User-Authorization
+ * Server-Assignment
+ * Location-Info
+ * Multimedia-Auth
+ * Registration-Termination
+ * Push-Profile
 
 The stack includes also a generic fallback Python class for every other message.

--- a/src/diameter/message/avp/generator.py
+++ b/src/diameter/message/avp/generator.py
@@ -47,6 +47,9 @@ def generate_avps_from_defs(obj: AvpGenerator, strict: bool = False) -> list[Avp
         return avp_list
 
     for gen_def in obj.avp_def:
+        # catch early cases where avp_def exists contains junk
+        if not isinstance(gen_def, AvpGenDef):
+            continue
         if not hasattr(obj, gen_def.attr_name) and gen_def.is_required:
             msg = f"mandatory AVP attribute `{gen_def.attr_name}` is not set"
             if strict:

--- a/src/diameter/message/avp/grouped.py
+++ b/src/diameter/message/avp/grouped.py
@@ -996,15 +996,73 @@ class ServerCapabilities:
 
 
 @dataclasses.dataclass
+class SipDigestAuthenticate:
+    """A data container that represents the "SIP-Digest-Authenticate" (635) grouped AVP.
+
+    3GPP TS 29.229 version 13.1.0
+    """
+    digest_realm: str = None
+    digest_algorithm: str = None
+    digest_qop: str = None
+    digest_ha1: str = None
+    additional_avps: list[Avp] = dataclasses.field(default_factory=list)
+
+    # noinspection PyDataclass
+    avp_def: dataclasses.InitVar[AvpGenType] = (
+        AvpGenDef("digest_realm", AVP_DIGEST_REALM, is_required=True),
+        AvpGenDef("digest_qop", AVP_DIGEST_QOP),
+        AvpGenDef("digest_ha1", AVP_DIGEST_HA1, is_required=True),
+        AvpGenDef("digest_algorithm", AVP_DIGEST_ALGORITHM, is_required=True),
+    )
+
+
+@dataclasses.dataclass
+class SipAuthDataItem:
+    """A data container that represents the "SIP-Auth-Data-Item" (612) grouped AVP.
+
+    3GPP TS 29.229 version 13.1.0
+    """
+    sip_item_number: int = None
+    sip_authentication_scheme: int = None
+    sip_authenticate: bytes = None
+    sip_authorization: bytes = None
+    sip_authentication_context: bytes = None
+    confidentiality_key: bytes = None
+    integrity_key: bytes = None
+    sip_digest_authenticate: SipDigestAuthenticate = None
+    framed_ip_address: bytes = None
+    framed_ipv6_prefix: bytes = None
+    framed_interface_id: int = None
+    line_identifier: list[bytes] = dataclasses.field(default_factory=list)
+    additional_avps: list[Avp] = dataclasses.field(default_factory=list)
+
+    # noinspection PyDataclass
+    avp_def: dataclasses.InitVar[AvpGenType] = (
+        AvpGenDef("sip_item_number", AVP_SIP_ITEM_NUMBER),
+        AvpGenDef("sip_authentication_scheme", AVP_SIP_AUTHENTICATION_SCHEME),
+        AvpGenDef("sip_authenticate", AVP_TGPP_3GPP_SIP_AUTHENTICATE, VENDOR_TGPP),
+        AvpGenDef("sip_authorization", AVP_TGPP_3GPP_SIP_AUTHORIZATION, VENDOR_TGPP),
+        AvpGenDef("sip_authentication_context", AVP_TGPP_SIP_AUTHENTICATION_CONTEXT, VENDOR_TGPP),
+        AvpGenDef("confidentiality_key", AVP_TGPP_CONFIDENTIALITY_KEY, VENDOR_TGPP),
+        AvpGenDef("integrity_key", AVP_TGPP_INTEGRITY_KEY, VENDOR_TGPP),
+        AvpGenDef("sip_digest_authenticate", AVP_TGPP_SIP_DIGEST_AUTHENTICATE, VENDOR_TGPP, type_class=SipDigestAuthenticate),
+        AvpGenDef("framed_ip_address", AVP_FRAMED_IP_ADDRESS),
+        AvpGenDef("framed_ipv6_prefix", AVP_FRAMED_IPV6_PREFIX),
+        AvpGenDef("framed_interface_id", AVP_FRAMED_INTERFACE_ID),
+        AvpGenDef("line_identifier", AVP_ETSI_LINE_IDENTIFIER, VENDOR_ETSI)
+    )
+
+
+@dataclasses.dataclass
 class ChargingInformation:
     """A data container that represents the "Charging-Information" (618) grouped AVP.
 
     3GPP TS 29.229 version 13.1.0
     """
-    primary_event_charging_function_name: str
-    secondary_event_charging_function_name: str
-    primary_charging_collection_function_name: str
-    secondary_charging_collection_function_name: str
+    primary_event_charging_function_name: str = None
+    secondary_event_charging_function_name: str = None
+    primary_charging_collection_function_name: str = None
+    secondary_charging_collection_function_name: str = None
     additional_avps: list[Avp] = dataclasses.field(default_factory=list)
 
     # noinspection PyDataclass

--- a/src/diameter/message/avp/grouped.py
+++ b/src/diameter/message/avp/grouped.py
@@ -1054,6 +1054,23 @@ class SipAuthDataItem:
 
 
 @dataclasses.dataclass
+class DeregistrationReason:
+    """A data container that represents the "Deregistration-Reason" (615) grouped AVP.
+
+    3GPP TS 29.229 version 13.1.0
+    """
+    reason_code: int = None
+    reason_info: str = None
+    additional_avps: list[Avp] = dataclasses.field(default_factory=list)
+
+    # noinspection PyDataclass
+    avp_def: dataclasses.InitVar[AvpGenType] = (
+        AvpGenDef("reason_code", AVP_TGPP_REASON_CODE, VENDOR_TGPP),
+        AvpGenDef("reason_info", AVP_TGPP_REASON_INFO, VENDOR_TGPP)
+    )
+
+
+@dataclasses.dataclass
 class ChargingInformation:
     """A data container that represents the "Charging-Information" (618) grouped AVP.
 
@@ -1185,6 +1202,23 @@ class ScscfRestorationInfo:
         AvpGenDef("user_name", AVP_USER_NAME, is_required=True),
         AvpGenDef("restoration_info", AVP_TGPP_RESTORATION_INFO, VENDOR_TGPP, is_required=True, type_class=RestorationInfo),
         AvpGenDef("sip_authentication_scheme", AVP_SIP_AUTHENTICATION_SCHEME),
+    )
+
+
+@dataclasses.dataclass
+class IdentityWithEmergencyRegistration:
+    """A data container that represents the "Identity-with-Emergency-Registration" (651) grouped AVP.
+
+    3GPP TS 29.229 version 13.1.0
+    """
+    user_name: str = None
+    public_identity: str = None
+    additional_avps: list[Avp] = dataclasses.field(default_factory=list)
+
+    # noinspection PyDataclass
+    avp_def: dataclasses.InitVar[AvpGenType] = (
+        AvpGenDef("user_name", AVP_USER_NAME, is_required=True),
+        AvpGenDef("public_identity", AVP_TGPP_PUBLIC_IDENTITY, VENDOR_TGPP, is_required=True)
     )
 
 

--- a/src/diameter/message/avp/grouped.py
+++ b/src/diameter/message/avp/grouped.py
@@ -996,6 +996,27 @@ class ServerCapabilities:
 
 
 @dataclasses.dataclass
+class ChargingInformation:
+    """A data container that represents the "Charging-Information" (618) grouped AVP.
+
+    3GPP TS 29.229 version 13.1.0
+    """
+    primary_event_charging_function_name: str
+    secondary_event_charging_function_name: str
+    primary_charging_collection_function_name: str
+    secondary_charging_collection_function_name: str
+    additional_avps: list[Avp] = dataclasses.field(default_factory=list)
+
+    # noinspection PyDataclass
+    avp_def: dataclasses.InitVar[AvpGenType] = (
+        AvpGenDef("primary_event_charging_function_name", AVP_TGPP_PRIMARY_EVENT_CHARGING_FUNCTION_NAME, VENDOR_TGPP),
+        AvpGenDef("secondary_event_charging_function_name", AVP_TGPP_SECONDARY_EVENT_CHARGING_FUNCTION_NAME, VENDOR_TGPP),
+        AvpGenDef("primary_charging_collection_function_name", AVP_TGPP_PRIMARY_CHARGING_COLLECTION_FUNCTION_NAME, VENDOR_TGPP),
+        AvpGenDef("secondary_charging_collection_function_name", AVP_TGPP_SECONDARY_CHARGING_COLLECTION_FUNCTION_NAME, VENDOR_TGPP),
+    )
+
+
+@dataclasses.dataclass
 class SupportedFeatures:
     """A data container that represents the "Supported-Features" (628) grouped AVP.
 
@@ -1011,6 +1032,118 @@ class SupportedFeatures:
         AvpGenDef("vendor_id", AVP_VENDOR_ID, is_required=True),
         AvpGenDef("feature_list_id", AVP_TGPP_FEATURE_LIST_ID, VENDOR_TGPP, is_required=True),
         AvpGenDef("feature_list", AVP_TGPP_FEATURE_LIST, VENDOR_TGPP, is_required=True),
+    )
+
+
+@dataclasses.dataclass
+class AssociatedIdentities:
+    """A data container that represents the "Associated-Identities" (632) grouped AVP.
+
+    3GPP TS 29.229 version 13.1.0
+    """
+    user_name: list[str] = dataclasses.field(default_factory=list)
+    additional_avps: list[Avp] = dataclasses.field(default_factory=list)
+
+    # noinspection PyDataclass
+    avp_def: dataclasses.InitVar[AvpGenType] = (
+        AvpGenDef("user_name", AVP_USER_NAME, is_required=True),
+    )
+
+
+@dataclasses.dataclass
+class SubscriptionInfo:
+    """A data container that represents the "Subscription-Info" (642) grouped AVP.
+
+    3GPP TS 29.229 version 13.1.0
+    """
+    call_id_sip_header: bytes = None
+    from_sip_header: bytes = None
+    to_sip_header: bytes = None
+    record_route: bytes = None
+    contact: bytes = None
+    additional_avps: list[Avp] = dataclasses.field(default_factory=list)
+
+    # noinspection PyDataclass
+    avp_def: dataclasses.InitVar[AvpGenType] = (
+        AvpGenDef("call_id_sip_header", AVP_TGPP_CALL_ID_SIP_HEADER, VENDOR_TGPP, is_required=True),
+        AvpGenDef("from_sip_header", AVP_TGPP_FROM_SIP_HEADER, VENDOR_TGPP, is_required=True),
+        AvpGenDef("to_sip_header", AVP_TGPP_TO_SIP_HEADER, VENDOR_TGPP, is_required=True),
+        AvpGenDef("record_route", AVP_TGPP_RECORD_ROUTE, VENDOR_TGPP, is_required=True),
+        AvpGenDef("contact", AVP_TGPP_CONTACT, VENDOR_TGPP, is_required=True)
+    )
+
+
+@dataclasses.dataclass
+class AssociatedRegisteredIdentities:
+    """A data container that represents the "Associated-Registered-Identities" (647) grouped AVP.
+
+    3GPP TS 29.229 version 13.1.0
+    """
+    user_name: list[str] = dataclasses.field(default_factory=list)
+    additional_avps: list[Avp] = dataclasses.field(default_factory=list)
+
+    # noinspection PyDataclass
+    avp_def: dataclasses.InitVar[AvpGenType] = (
+        AvpGenDef("user_name", AVP_USER_NAME, is_required=True),
+    )
+
+
+@dataclasses.dataclass
+class RestorationInfo:
+    """A data container that represents the "Restoration-Info" (649) grouped AVP.
+
+    3GPP TS 29.229 version 13.1.0
+    """
+    path: bytes = None
+    contact: bytes = None
+    initial_cseq_sequence_number: int = None
+    call_id_sip_header: bytes = None
+    subscription_info: SubscriptionInfo = None
+    additional_avps: list[Avp] = dataclasses.field(default_factory=list)
+
+    # noinspection PyDataclass
+    avp_def: dataclasses.InitVar[AvpGenType] = (
+        AvpGenDef("path", AVP_TGPP_PATH, VENDOR_TGPP, is_required=True),
+        AvpGenDef("contact", AVP_TGPP_CONTACT, VENDOR_TGPP, is_required=True),
+        AvpGenDef("initial_cseq_sequence_number", AVP_TGPP_INITIAL_CSEQ_SEQUENCE_NUMBER, VENDOR_TGPP),
+        AvpGenDef("call_id_sip_header", AVP_TGPP_CALL_ID_SIP_HEADER, VENDOR_TGPP),
+        AvpGenDef("subscription_info", AVP_TGPP_SUBSCRIPTION_INFO, VENDOR_TGPP, type_class=SubscriptionInfo),
+    )
+
+
+@dataclasses.dataclass
+class ScscfRestorationInfo:
+    """A data container that represents the "SCSCF-Restoration-Info" (639) grouped AVP.
+
+    3GPP TS 29.229 version 13.1.0
+    """
+    user_name: str = None
+    restoration_info: RestorationInfo = None
+    sip_authentication_scheme: int = None
+    additional_avps: list[Avp] = dataclasses.field(default_factory=list)
+
+    # noinspection PyDataclass
+    avp_def: dataclasses.InitVar[AvpGenType] = (
+        AvpGenDef("user_name", AVP_USER_NAME, is_required=True),
+        AvpGenDef("restoration_info", AVP_TGPP_RESTORATION_INFO, VENDOR_TGPP, is_required=True, type_class=RestorationInfo),
+        AvpGenDef("sip_authentication_scheme", AVP_SIP_AUTHENTICATION_SCHEME),
+    )
+
+
+@dataclasses.dataclass
+class AllowedWafWwsfIdentities:
+    """A data container that represents the "Allowed-WAF-WWSF-Identities" (656) grouped AVP.
+
+    3GPP TS 29.229 version 13.1.0
+    """
+    webrtc_authentication_function_name: list[str] = dataclasses.field(default_factory=list)
+    webrtc_web_server_function_name: list[str] = dataclasses.field(default_factory=list)
+    additional_avps: list[Avp] = dataclasses.field(default_factory=list)
+
+    # noinspection PyDataclass
+    avp_def: dataclasses.InitVar[AvpGenType] = (
+        AvpGenDef("webrtc_authentication_function_name", AVP_TGPP_WEBRTC_AUTHENTICATION_FUNCTION_NAME, VENDOR_TGPP, is_required=True),
+        AvpGenDef("webrtc_web_server_function_name", AVP_TGPP_WEBRTC_WEB_SERVER_FUNCTION_NAME, VENDOR_TGPP, is_required=True)
     )
 
 

--- a/src/diameter/message/avp/grouped.py
+++ b/src/diameter/message/avp/grouped.py
@@ -909,7 +909,7 @@ class OcSupportedFeatures:
 
     # noinspection PyDataclass
     avp_def: dataclasses.InitVar[AvpGenType] = (
-        AvpGenDef("vendor_id", AVP_OC_FEATURE_VECTOR),
+        AvpGenDef("oc_feature_vector", AVP_OC_FEATURE_VECTOR),
     )
 
 

--- a/src/diameter/message/commands/__init__.py
+++ b/src/diameter/message/commands/__init__.py
@@ -19,6 +19,7 @@ from .device_watchdog import *
 from .diameter_eap import *
 from .disconnect_peer import *
 from .home_agent_mip import *
+from .multimedia_auth import *
 from .re_auth import *
 from .server_assignment import *
 from .spending_limit import *
@@ -132,21 +133,6 @@ class LocationInfo(UndefinedMessage):
     """
     code: int = 302
     name: str = "Location-Info"
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.header.command_code = self.code
-
-
-class MultimediaAuth(UndefinedMessage):
-    """A Multimedia-Auth message.
-
-    This message implementation provides no python subclasses for requests and
-    answers; AVPs must be created manually and added using the
-    [MultimediaAuth.append_avp][diameter.message.Message.append_avp] method.
-    """
-    code: int = 303
-    name: str = "Multimedia-Auth"
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/diameter/message/commands/__init__.py
+++ b/src/diameter/message/commands/__init__.py
@@ -19,6 +19,7 @@ from .device_watchdog import *
 from .diameter_eap import *
 from .disconnect_peer import *
 from .home_agent_mip import *
+from .location_info import *
 from .multimedia_auth import *
 from .re_auth import *
 from .server_assignment import *
@@ -118,21 +119,6 @@ class SipPushProfile(UndefinedMessage):
     """
     code: int = 288
     name: str = "SIP-Push-Profile"
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.header.command_code = self.code
-
-
-class LocationInfo(UndefinedMessage):
-    """A Location-Info message.
-
-    This message implementation provides no python subclasses for requests and
-    answers; AVPs must be created manually and added using the
-    [LocationInfo.append_avp][diameter.message.Message.append_avp] method.
-    """
-    code: int = 302
-    name: str = "Location-Info"
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/diameter/message/commands/__init__.py
+++ b/src/diameter/message/commands/__init__.py
@@ -22,6 +22,7 @@ from .home_agent_mip import *
 from .location_info import *
 from .multimedia_auth import *
 from .re_auth import *
+from .registration_termination import *
 from .server_assignment import *
 from .spending_limit import *
 from .spending_status_notification import *
@@ -119,21 +120,6 @@ class SipPushProfile(UndefinedMessage):
     """
     code: int = 288
     name: str = "SIP-Push-Profile"
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.header.command_code = self.code
-
-
-class RegistrationTermination(UndefinedMessage):
-    """A Registration-Termination message.
-
-    This message implementation provides no python subclasses for requests and
-    answers; AVPs must be created manually and added using the
-    [AaMobileNode.append_avpRegistrationTerminationdiameter.message.Message.append_avp] method.
-    """
-    code: int = 304
-    name: str = "Registration-Termination"
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/diameter/message/commands/__init__.py
+++ b/src/diameter/message/commands/__init__.py
@@ -23,6 +23,7 @@ from .re_auth import *
 from .spending_limit import *
 from .spending_status_notification import *
 from .session_termination import *
+from .user_authorization import *
 
 
 # Remaining Message types that have no implementation (yet), either because
@@ -115,21 +116,6 @@ class SipPushProfile(UndefinedMessage):
     """
     code: int = 288
     name: str = "SIP-Push-Profile"
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.header.command_code = self.code
-
-
-class UserAuthorization(UndefinedMessage):
-    """A User-Authorization message.
-
-    This message implementation provides no python subclasses for requests and
-    answers; AVPs must be created manually and added using the
-    [UserAuthorization.append_avp][diameter.message.Message.append_avp] method.
-    """
-    code: int = 300
-    name: str = "User-Authorization"
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/diameter/message/commands/__init__.py
+++ b/src/diameter/message/commands/__init__.py
@@ -21,6 +21,7 @@ from .disconnect_peer import *
 from .home_agent_mip import *
 from .location_info import *
 from .multimedia_auth import *
+from .push_profile import *
 from .re_auth import *
 from .registration_termination import *
 from .server_assignment import *
@@ -120,21 +121,6 @@ class SipPushProfile(UndefinedMessage):
     """
     code: int = 288
     name: str = "SIP-Push-Profile"
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.header.command_code = self.code
-
-
-class PushProfile(UndefinedMessage):
-    """A Push-Profile message.
-
-    This message implementation provides no python subclasses for requests and
-    answers; AVPs must be created manually and added using the
-    [PushProfile.append_avp][diameter.message.Message.append_avp] method.
-    """
-    code: int = 305
-    name: str = "Push-Profile"
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/diameter/message/commands/__init__.py
+++ b/src/diameter/message/commands/__init__.py
@@ -20,6 +20,7 @@ from .diameter_eap import *
 from .disconnect_peer import *
 from .home_agent_mip import *
 from .re_auth import *
+from .server_assignment import *
 from .spending_limit import *
 from .spending_status_notification import *
 from .session_termination import *
@@ -116,21 +117,6 @@ class SipPushProfile(UndefinedMessage):
     """
     code: int = 288
     name: str = "SIP-Push-Profile"
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.header.command_code = self.code
-
-
-class ServerAssignment(UndefinedMessage):
-    """A Server-Assignment message.
-
-    This message implementation provides no python subclasses for requests and
-    answers; AVPs must be created manually and added using the
-    [ServerAssignment.append_avp][diameter.message.Message.append_avp] method.
-    """
-    code: int = 301
-    name: str = "Server-Assignment"
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/diameter/message/commands/location_info.py
+++ b/src/diameter/message/commands/location_info.py
@@ -1,0 +1,194 @@
+"""
+Diameter Cx/Dx Interface.
+
+This module contains Location Info Request and Answer messages,
+implementing AVPs documented in 3GPP TS 29.229.
+"""
+from __future__ import annotations
+
+from typing import Type
+
+from .._base import Message, MessageHeader, DefinedMessage, _AnyMessageType
+from ..avp.grouped import *
+from ..avp.generator import AvpGenDef, AvpGenType
+from ._attributes import assign_attr_from_defs
+
+
+__all__ = ["LocationInfo", "LocationInfoAnswer", "LocationInfoRequest"]
+
+
+class LocationInfo(DefinedMessage):
+    """A Location-Info base message.
+
+    This message class lists message attributes based on the current 3GPP TS
+    29.229 version 13.1.0 Release 13 as python properties, accessible as
+    instance attributes. AVPs not listed in the spec protocol can be
+    retrieved using the
+    [LocationInfo.find_avps][diameter.message.Message.find_avps] search
+    method.
+
+    Examples:
+        AVPs accessible either as instance attributes or by searching:
+
+        >>> msg = Message.from_bytes(b"...")
+        >>> msg.session_id
+        dra1.mvno.net;2323;546
+        >>> msg.find_avps((AVP_SESSION_ID, 0))
+        ['dra1.mvno.net;2323;546']
+
+        When a diameter message is decoded using
+        [Message.from_bytes][diameter.message.Message.from_bytes], it returns
+        either an instance of `LocationInfoRequest` or
+        `LocationInfoAnswer` automatically:
+
+        >>> msg = Message.from_bytes(b"...")
+        >>> assert msg.header.is_request is True
+        >>> assert isinstance(msg, LocationInfoRequest)
+
+        When creating a new message, the `LocationInfoRequest` or
+        `LocationInfoAnswer` class should be instantiated directly, and
+        values for AVPs set as class attributes:
+
+        >>> msg = LocationInfoRequest()
+        >>> msg.session_id = "dra1.mvno.net;2323;546"
+
+    Other, custom AVPs can be appended to the message using the
+    [LocationInfo.append_avp][diameter.message.Message.append_avp] method,
+    or by overwriting the `avp` attribute entirely. Regardless of the custom
+    AVPs set, the mandatory values listed in TS 29.229 must be set, however,
+    they can be set as `None`, if they are not to be used.
+
+    !!! Warning
+        Every AVP documented for the subclasses of this command can be accessed
+        as an instance attribute, even if the original network-received message
+        did not contain that specific AVP. Such AVPs will be returned with the
+        value `None` when accessed.
+
+        Every other AVP not mentioned here, and not present in a
+        network-received message will raise an `AttributeError` when being
+        accessed; their presence should be validated with `hasattr` before
+        accessing.
+
+    """
+    code: int = 302
+    name: str = "Location-Info"
+    avp_def: AvpGenType
+
+    def __post_init__(self):
+        self.header.command_code = self.code
+        super().__post_init__()
+
+    @classmethod
+    def type_factory(cls, header: MessageHeader) -> Type[_AnyMessageType] | None:
+        if header.is_request:
+            return LocationInfoRequest
+        return LocationInfoAnswer
+
+
+class LocationInfoAnswer(LocationInfo):
+    """A Location-Info-Answer message."""
+    session_id: str
+    drmp: int
+    vendor_specific_application_id: VendorSpecificApplicationId
+    result_code: int
+    experimental_result: ExperimentalResult
+    auth_session_state: int
+    origin_host: bytes
+    origin_realm: bytes
+    oc_supported_features: OcSupportedFeatures
+    oc_olr: OcOlr
+    supported_features: list[SupportedFeatures]
+    server_name: str
+    server_capabilities: ServerCapabilities
+    wildcarded_public_identity: str
+    lia_flags: int
+    failed_avp: list[FailedAvp]
+    proxy_info: list[ProxyInfo]
+    route_record: list[bytes]
+
+    avp_def: AvpGenType = (
+        AvpGenDef("session_id", AVP_SESSION_ID, is_required=True),
+        AvpGenDef("drmp", AVP_DRMP),
+        AvpGenDef("vendor_specific_application_id", AVP_VENDOR_SPECIFIC_APPLICATION_ID, is_required=True, type_class=VendorSpecificApplicationId),
+        AvpGenDef("result_code", AVP_RESULT_CODE),
+        AvpGenDef("experimental_result", AVP_EXPERIMENTAL_RESULT, type_class=ExperimentalResult),
+        AvpGenDef("auth_session_state", AVP_AUTH_SESSION_STATE),
+        AvpGenDef("origin_host", AVP_ORIGIN_HOST, is_required=True),
+        AvpGenDef("origin_realm", AVP_ORIGIN_REALM, is_required=True),
+        AvpGenDef("oc_supported_features", AVP_OC_SUPPORTED_FEATURES, type_class=OcSupportedFeatures),
+        AvpGenDef("oc_olr", AVP_OC_OLR, type_class=OcOlr),
+        AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
+        AvpGenDef("server_name", AVP_TGPP_SERVER_NAME, VENDOR_TGPP, is_required=True),
+        AvpGenDef("server_capabilities", AVP_TGPP_SERVER_CAPABILITIES, VENDOR_TGPP, type_class=ServerCapabilities),
+        AvpGenDef("wildcarded_public_identity", AVP_TGPP_WILDCARDED_PSI, VENDOR_TGPP),
+        AvpGenDef("lia_flags", AVP_TGPP_LIA_FLAGS, VENDOR_TGPP),
+        AvpGenDef("failed_avp", AVP_FAILED_AVP, type_class=FailedAvp),
+        AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
+        AvpGenDef("route_record", AVP_ROUTE_RECORD)
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.header.is_request = False
+        self.header.is_proxyable = True
+
+        setattr(self, "supported_features", [])
+        setattr(self, "failed_avp", [])
+        setattr(self, "proxy_info", [])
+        setattr(self, "route_record", [])
+
+        assign_attr_from_defs(self, self._avps)
+        self._avps = []
+
+
+class LocationInfoRequest(LocationInfo):
+    """A Location-Info-Request message."""
+    session_id: str
+    drmp: int
+    vendor_specific_application_id: VendorSpecificApplicationId
+    auth_session_state: int
+    origin_host: bytes
+    origin_realm: bytes
+    destination_host: bytes
+    destination_realm: bytes
+    user_name: str
+    oc_supported_features: OcSupportedFeatures
+    supported_features: list[SupportedFeatures]
+    public_identity: str
+    sip_auth_data_item: SipAuthDataItem
+    sip_number_auth_items: int
+    server_name: str
+    proxy_info: list[ProxyInfo]
+    route_record: list[bytes]
+
+    avp_def: AvpGenType = (
+        AvpGenDef("session_id", AVP_SESSION_ID, is_required=True),
+        AvpGenDef("drmp", AVP_DRMP),
+        AvpGenDef("vendor_specific_application_id", AVP_VENDOR_SPECIFIC_APPLICATION_ID, is_required=True, type_class=VendorSpecificApplicationId),
+        AvpGenDef("auth_session_state", AVP_AUTH_SESSION_STATE, is_required=True),
+        AvpGenDef("origin_host", AVP_ORIGIN_HOST, is_required=True),
+        AvpGenDef("origin_realm", AVP_ORIGIN_REALM, is_required=True),
+        AvpGenDef("destination_host", AVP_DESTINATION_HOST),
+        AvpGenDef("destination_realm", AVP_DESTINATION_REALM, is_required=True),
+        AvpGenDef("user_name", AVP_USER_NAME, is_required=True),
+        AvpGenDef("oc_supported_features", AVP_OC_SUPPORTED_FEATURES, type_class=OcSupportedFeatures),
+        AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
+        AvpGenDef("public_identity", AVP_TGPP_PUBLIC_IDENTITY, VENDOR_TGPP, is_required=True),
+        AvpGenDef("sip_auth_data_item", AVP_SIP_AUTH_DATA_ITEM, is_required=True, type_class=SipAuthDataItem),
+        AvpGenDef("sip_number_auth_items", AVP_SIP_NUMBER_AUTH_ITEMS, is_required=True),
+        AvpGenDef("server_name", AVP_TGPP_SERVER_NAME, VENDOR_TGPP, is_required=True),
+        AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
+        AvpGenDef("route_record", AVP_ROUTE_RECORD)
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.header.is_request = True
+        self.header.is_proxyable = True
+
+        setattr(self, "supported_features", [])
+        setattr(self, "proxy_info", [])
+        setattr(self, "route_record", [])
+
+        assign_attr_from_defs(self, self._avps)
+        self._avps = []

--- a/src/diameter/message/commands/multimedia_auth.py
+++ b/src/diameter/message/commands/multimedia_auth.py
@@ -1,0 +1,195 @@
+"""
+Diameter Cx/Dx Interface.
+
+This module contains Multimedia Auth Request and Answer messages,
+implementing AVPs documented in 3GPP TS 29.229.
+"""
+from __future__ import annotations
+
+from typing import Type
+
+from .._base import Message, MessageHeader, DefinedMessage, _AnyMessageType
+from ..avp.grouped import *
+from ..avp.generator import AvpGenDef, AvpGenType
+from ._attributes import assign_attr_from_defs
+
+
+__all__ = ["MultimediaAuth", "MultimediaAuthAnswer", "MultimediaAuthRequest"]
+
+
+class MultimediaAuth(DefinedMessage):
+    """A Multimedia-Auth base message.
+
+    This message class lists message attributes based on the current 3GPP TS
+    29.229 version 13.1.0 Release 13 as python properties, accessible as
+    instance attributes. AVPs not listed in the spec protocol can be
+    retrieved using the
+    [MultimediaAuth.find_avps][diameter.message.Message.find_avps] search
+    method.
+
+    Examples:
+        AVPs accessible either as instance attributes or by searching:
+
+        >>> msg = Message.from_bytes(b"...")
+        >>> msg.session_id
+        dra1.mvno.net;2323;546
+        >>> msg.find_avps((AVP_SESSION_ID, 0))
+        ['dra1.mvno.net;2323;546']
+
+        When a diameter message is decoded using
+        [Message.from_bytes][diameter.message.Message.from_bytes], it returns
+        either an instance of `MultimediaAuthRequest` or
+        `MultimediaAuthAnswer` automatically:
+
+        >>> msg = Message.from_bytes(b"...")
+        >>> assert msg.header.is_request is True
+        >>> assert isinstance(msg, MultimediaAuthRequest)
+
+        When creating a new message, the `MultimediaAuthRequest` or
+        `MultimediaAuthAnswer` class should be instantiated directly, and
+        values for AVPs set as class attributes:
+
+        >>> msg = MultimediaAuthRequest()
+        >>> msg.session_id = "dra1.mvno.net;2323;546"
+
+    Other, custom AVPs can be appended to the message using the
+    [MultimediaAuth.append_avp][diameter.message.Message.append_avp] method,
+    or by overwriting the `avp` attribute entirely. Regardless of the custom
+    AVPs set, the mandatory values listed in TS 29.229 must be set, however
+    they can be set as `None`, if they are not to be used.
+
+    !!! Warning
+        Every AVP documented for the subclasses of this command can be accessed
+        as an instance attribute, even if the original network-received message
+        did not contain that specific AVP. Such AVPs will be returned with the
+        value `None` when accessed.
+
+        Every other AVP not mentioned here, and not present in a
+        network-received message will raise an `AttributeError` when being
+        accessed; their presence should be validated with `hasattr` before
+        accessing.
+
+    """
+    code: int = 303
+    name: str = "Multimedia-Auth"
+    avp_def: AvpGenType
+
+    def __post_init__(self):
+        self.header.command_code = self.code
+        super().__post_init__()
+
+    @classmethod
+    def type_factory(cls, header: MessageHeader) -> Type[_AnyMessageType] | None:
+        if header.is_request:
+            return MultimediaAuthRequest
+        return MultimediaAuthAnswer
+
+
+class MultimediaAuthAnswer(MultimediaAuth):
+    """A Multimedia-Auth-Answer message."""
+    session_id: str
+    drmp: int
+    vendor_specific_application_id: VendorSpecificApplicationId
+    result_code: int
+    experimental_result: ExperimentalResult
+    auth_session_state: int
+    origin_host: bytes
+    origin_realm: bytes
+    oc_supported_features: OcSupportedFeatures
+    oc_olr: OcOlr
+    supported_features: list[SupportedFeatures]
+    public_identity: str
+    sip_number_auth_items: int
+    sip_auth_data_item: list[SipAuthDataItem]
+    failed_avp: list[FailedAvp]
+    proxy_info: list[ProxyInfo]
+    route_record: list[bytes]
+
+    avp_def: AvpGenType = (
+        AvpGenDef("session_id", AVP_SESSION_ID, is_required=True),
+        AvpGenDef("drmp", AVP_DRMP),
+        AvpGenDef("vendor_specific_application_id", AVP_VENDOR_SPECIFIC_APPLICATION_ID, is_required=True, type_class=VendorSpecificApplicationId),
+        AvpGenDef("result_code", AVP_RESULT_CODE),
+        AvpGenDef("experimental_result", AVP_EXPERIMENTAL_RESULT, type_class=ExperimentalResult),
+        AvpGenDef("auth_session_state", AVP_AUTH_SESSION_STATE),
+        AvpGenDef("origin_host", AVP_ORIGIN_HOST, is_required=True),
+        AvpGenDef("origin_realm", AVP_ORIGIN_REALM, is_required=True),
+        AvpGenDef("oc_supported_features", AVP_OC_SUPPORTED_FEATURES, type_class=OcSupportedFeatures),
+        AvpGenDef("oc_olr", AVP_OC_OLR, type_class=OcOlr),
+        AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
+        AvpGenDef("public_identity", AVP_TGPP_PUBLIC_IDENTITY, VENDOR_TGPP, is_required=True),
+        AvpGenDef("sip_number_auth_items", AVP_SIP_NUMBER_AUTH_ITEMS),
+        AvpGenDef("sip_auth_data_item", AVP_SIP_AUTH_DATA_ITEM, type_class=SipAuthDataItem),
+        AvpGenDef("failed_avp", AVP_FAILED_AVP, type_class=FailedAvp),
+        AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
+        AvpGenDef("route_record", AVP_ROUTE_RECORD)
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.header.is_request = False
+        self.header.is_proxyable = True
+
+        setattr(self, "supported_features", [])
+        setattr(self, "sip_auth_data_item", [])
+        setattr(self, "failed_avp", [])
+        setattr(self, "proxy_info", [])
+        setattr(self, "route_record", [])
+
+        assign_attr_from_defs(self, self._avps)
+        self._avps = []
+
+
+class MultimediaAuthRequest(MultimediaAuth):
+    """A Multimedia-Auth-Request message."""
+    session_id: str
+    drmp: int
+    vendor_specific_application_id: VendorSpecificApplicationId
+    auth_session_state: int
+    origin_host: bytes
+    origin_realm: bytes
+    destination_host: bytes
+    destination_realm: bytes
+    user_name: str
+    oc_supported_features: OcSupportedFeatures
+    supported_features: list[SupportedFeatures]
+    public_identity: list[str]
+    sip_auth_data_item: SipAuthDataItem
+    sip_number_auth_items: int
+    server_name: str
+    proxy_info: list[ProxyInfo]
+    route_record: list[bytes]
+
+    avp_def: AvpGenType = (
+        AvpGenDef("session_id", AVP_SESSION_ID, is_required=True),
+        AvpGenDef("drmp", AVP_DRMP),
+        AvpGenDef("vendor_specific_application_id", AVP_VENDOR_SPECIFIC_APPLICATION_ID, is_required=True, type_class=VendorSpecificApplicationId),
+        AvpGenDef("auth_session_state", AVP_AUTH_SESSION_STATE, is_required=True),
+        AvpGenDef("origin_host", AVP_ORIGIN_HOST, is_required=True),
+        AvpGenDef("origin_realm", AVP_ORIGIN_REALM, is_required=True),
+        AvpGenDef("destination_host", AVP_DESTINATION_HOST),
+        AvpGenDef("destination_realm", AVP_DESTINATION_REALM, is_required=True),
+        AvpGenDef("user_name", AVP_USER_NAME, is_required=True),
+        AvpGenDef("oc_supported_features", AVP_OC_SUPPORTED_FEATURES, type_class=OcSupportedFeatures),
+        AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
+        AvpGenDef("public_identity", AVP_TGPP_PUBLIC_IDENTITY, VENDOR_TGPP),
+        AvpGenDef("sip_auth_data_item", AVP_SIP_AUTH_DATA_ITEM, type_class=SipAuthDataItem, is_required=True),
+        AvpGenDef("sip_number_auth_items", AVP_SIP_NUMBER_AUTH_ITEMS, is_required=True),
+        AvpGenDef("server_name", AVP_TGPP_SERVER_NAME, VENDOR_TGPP, is_required=True),
+        AvpGenDef("sar_flags", AVP_TGPP_SAR_FLAGS, VENDOR_TGPP),
+        AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
+        AvpGenDef("route_record", AVP_ROUTE_RECORD)
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.header.is_request = True
+        self.header.is_proxyable = True
+
+        setattr(self, "supported_features", [])
+        setattr(self, "public_identity", [])
+        setattr(self, "proxy_info", [])
+        setattr(self, "route_record", [])
+
+        assign_attr_from_defs(self, self._avps)
+        self._avps = []

--- a/src/diameter/message/commands/push_profile.py
+++ b/src/diameter/message/commands/push_profile.py
@@ -1,0 +1,180 @@
+"""
+Diameter Cx/Dx Interface.
+
+This module contains Push Profile Request and Answer messages,
+implementing AVPs documented in 3GPP TS 29.229.
+"""
+from __future__ import annotations
+
+from typing import Type
+
+from .._base import Message, MessageHeader, DefinedMessage, _AnyMessageType
+from ..avp.grouped import *
+from ..avp.generator import AvpGenDef, AvpGenType
+from ._attributes import assign_attr_from_defs
+
+
+__all__ = ["PushProfile", "PushProfileAnswer", "PushProfileRequest"]
+
+
+class PushProfile(DefinedMessage):
+    """A Push-Profile base message.
+
+    This message class lists message attributes based on the current 3GPP TS
+    29.229 version 13.1.0 Release 13 as python properties, accessible as
+    instance attributes. AVPs not listed in the spec protocol can be
+    retrieved using the
+    [PushProfile.find_avps][diameter.message.Message.find_avps] search
+    method.
+
+    Examples:
+        AVPs accessible either as instance attributes or by searching:
+
+        >>> msg = Message.from_bytes(b"...")
+        >>> msg.session_id
+        dra1.mvno.net;2323;546
+        >>> msg.find_avps((AVP_SESSION_ID, 0))
+        ['dra1.mvno.net;2323;546']
+
+        When a diameter message is decoded using
+        [Message.from_bytes][diameter.message.Message.from_bytes], it returns
+        either an instance of `PushProfileRequest` or
+        `PushProfileAnswer` automatically:
+
+        >>> msg = Message.from_bytes(b"...")
+        >>> assert msg.header.is_request is True
+        >>> assert isinstance(msg, PushProfileRequest)
+
+        When creating a new message, the `PushProfileRequest` or
+        `PushProfileAnswer` class should be instantiated directly, and
+        values for AVPs set as class attributes:
+
+        >>> msg = PushProfileRequest()
+        >>> msg.session_id = "dra1.mvno.net;2323;546"
+
+    Other, custom AVPs can be appended to the message using the
+    [PushProfile.append_avp][diameter.message.Message.append_avp] method,
+    or by overwriting the `avp` attribute entirely. Regardless of the custom
+    AVPs set, the mandatory values listed in TS 29.229 must be set, however,
+    they can be set as `None`, if they are not to be used.
+
+    !!! Warning
+        Every AVP documented for the subclasses of this command can be accessed
+        as an instance attribute, even if the original network-received message
+        did not contain that specific AVP. Such AVPs will be returned with the
+        value `None` when accessed.
+
+        Every other AVP not mentioned here, and not present in a
+        network-received message will raise an `AttributeError` when being
+        accessed; their presence should be validated with `hasattr` before
+        accessing.
+
+    """
+    code: int = 305
+    name: str = "Push-Profile"
+    avp_def: AvpGenType
+
+    def __post_init__(self):
+        self.header.command_code = self.code
+        super().__post_init__()
+
+    @classmethod
+    def type_factory(cls, header: MessageHeader) -> Type[_AnyMessageType] | None:
+        if header.is_request:
+            return PushProfileRequest
+        return PushProfileAnswer
+
+
+class PushProfileAnswer(PushProfile):
+    """A Push-Profile-Answer message."""
+    session_id: str
+    drmp: int
+    vendor_specific_application_id: VendorSpecificApplicationId
+    result_code: int
+    experimental_result: ExperimentalResult
+    auth_session_state: int
+    origin_host: bytes
+    origin_realm: bytes
+    supported_features: list[SupportedFeatures]
+    failed_avp: list[FailedAvp]
+    proxy_info: list[ProxyInfo]
+    route_record: list[bytes]
+
+    avp_def: AvpGenType = (
+        AvpGenDef("session_id", AVP_SESSION_ID, is_required=True),
+        AvpGenDef("drmp", AVP_DRMP),
+        AvpGenDef("vendor_specific_application_id", AVP_VENDOR_SPECIFIC_APPLICATION_ID, is_required=True, type_class=VendorSpecificApplicationId),
+        AvpGenDef("result_code", AVP_RESULT_CODE),
+        AvpGenDef("experimental_result", AVP_EXPERIMENTAL_RESULT, type_class=ExperimentalResult),
+        AvpGenDef("auth_session_state", AVP_AUTH_SESSION_STATE),
+        AvpGenDef("origin_host", AVP_ORIGIN_HOST, is_required=True),
+        AvpGenDef("origin_realm", AVP_ORIGIN_REALM, is_required=True),
+        AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
+        AvpGenDef("failed_avp", AVP_FAILED_AVP, type_class=FailedAvp),
+        AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
+        AvpGenDef("route_record", AVP_ROUTE_RECORD)
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.header.is_request = False
+        self.header.is_proxyable = True
+
+        setattr(self, "supported_features", [])
+        setattr(self, "failed_avp", [])
+        setattr(self, "proxy_info", [])
+        setattr(self, "route_record", [])
+
+        assign_attr_from_defs(self, self._avps)
+        self._avps = []
+
+
+class PushProfileRequest(PushProfile):
+    """A Push-Profile-Request message."""
+    session_id: str
+    drmp: int
+    vendor_specific_application_id: VendorSpecificApplicationId
+    auth_session_state: int
+    origin_host: bytes
+    origin_realm: bytes
+    destination_host: bytes
+    destination_realm: bytes
+    user_name: str
+    supported_features: list[SupportedFeatures]
+    user_data: bytes
+    charging_information: ChargingInformation
+    sip_auth_data_item: SipAuthDataItem
+    allowed_waf_wwsf_identities: AllowedWafWwsfIdentities
+    proxy_info: list[ProxyInfo]
+    route_record: list[bytes]
+
+    avp_def: AvpGenType = (
+        AvpGenDef("session_id", AVP_SESSION_ID, is_required=True),
+        AvpGenDef("drmp", AVP_DRMP),
+        AvpGenDef("vendor_specific_application_id", AVP_VENDOR_SPECIFIC_APPLICATION_ID, is_required=True, type_class=VendorSpecificApplicationId),
+        AvpGenDef("auth_session_state", AVP_AUTH_SESSION_STATE, is_required=True),
+        AvpGenDef("origin_host", AVP_ORIGIN_HOST, is_required=True),
+        AvpGenDef("origin_realm", AVP_ORIGIN_REALM, is_required=True),
+        AvpGenDef("destination_host", AVP_DESTINATION_HOST),
+        AvpGenDef("destination_realm", AVP_DESTINATION_REALM, is_required=True),
+        AvpGenDef("user_name", AVP_USER_NAME, is_required=True),
+        AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
+        AvpGenDef("user_data", AVP_TGPP_CX_USER_DATA, VENDOR_TGPP),
+        AvpGenDef("charging_information", AVP_TGPP_CHARGING_INFORMATION, VENDOR_TGPP, type_class=ChargingInformation),
+        AvpGenDef("sip_auth_data_item", AVP_SIP_AUTH_DATA_ITEM, is_required=True, type_class=SipAuthDataItem),
+        AvpGenDef("allowed_waf_wwsf_identities", AVP_TGPP_ALLOWED_WAF_WWSF_IDENTITIES, VENDOR_TGPP, type_class=AllowedWafWwsfIdentities),
+        AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
+        AvpGenDef("route_record", AVP_ROUTE_RECORD)
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.header.is_request = True
+        self.header.is_proxyable = True
+
+        setattr(self, "supported_features", [])
+        setattr(self, "proxy_info", [])
+        setattr(self, "route_record", [])
+
+        assign_attr_from_defs(self, self._avps)
+        self._avps = []

--- a/src/diameter/message/commands/registration_termination.py
+++ b/src/diameter/message/commands/registration_termination.py
@@ -1,0 +1,184 @@
+"""
+Diameter Cx/Dx Interface.
+
+This module contains Registration Termination Request and Answer messages,
+implementing AVPs documented in 3GPP TS 29.229.
+"""
+from __future__ import annotations
+
+from typing import Type
+
+from .._base import Message, MessageHeader, DefinedMessage, _AnyMessageType
+from ..avp.grouped import *
+from ..avp.generator import AvpGenDef, AvpGenType
+from ._attributes import assign_attr_from_defs
+
+
+__all__ = ["RegistrationTermination", "RegistrationTerminationAnswer", "RegistrationTerminationRequest"]
+
+
+class RegistrationTermination(DefinedMessage):
+    """A Registration-Termination base message.
+
+    This message class lists message attributes based on the current 3GPP TS
+    29.229 version 13.1.0 Release 13 as python properties, accessible as
+    instance attributes. AVPs not listed in the spec protocol can be
+    retrieved using the
+    [RegistrationTermination.find_avps][diameter.message.Message.find_avps]
+    search method.
+
+    Examples:
+        AVPs accessible either as instance attributes or by searching:
+
+        >>> msg = Message.from_bytes(b"...")
+        >>> msg.session_id
+        dra1.mvno.net;2323;546
+        >>> msg.find_avps((AVP_SESSION_ID, 0))
+        ['dra1.mvno.net;2323;546']
+
+        When a diameter message is decoded using
+        [Message.from_bytes][diameter.message.Message.from_bytes], it returns
+        either an instance of `RegistrationTerminationRequest` or
+        `RegistrationTerminationAnswer` automatically:
+
+        >>> msg = Message.from_bytes(b"...")
+        >>> assert msg.header.is_request is True
+        >>> assert isinstance(msg, RegistrationTerminationRequest)
+
+        When creating a new message, the `RegistrationTerminationRequest` or
+        `RegistrationTerminationAnswer` class should be instantiated directly,
+        and values for AVPs set as class attributes:
+
+        >>> msg = RegistrationTerminationRequest()
+        >>> msg.session_id = "dra1.mvno.net;2323;546"
+
+    Other, custom AVPs can be appended to the message using the
+    [RegistrationTermination.append_avp][diameter.message.Message.append_avp]
+    method, or by overwriting the `avp` attribute entirely. Regardless of the
+    custom AVPs set, the mandatory values listed in TS 29.229 must be set,
+    however, they can be set as `None`, if they are not to be used.
+
+    !!! Warning
+        Every AVP documented for the subclasses of this command can be accessed
+        as an instance attribute, even if the original network-received message
+        did not contain that specific AVP. Such AVPs will be returned with the
+        value `None` when accessed.
+
+        Every other AVP not mentioned here, and not present in a
+        network-received message will raise an `AttributeError` when being
+        accessed; their presence should be validated with `hasattr` before
+        accessing.
+
+    """
+    code: int = 304
+    name: str = "Registration-Termination"
+    avp_def: AvpGenType
+
+    def __post_init__(self):
+        self.header.command_code = self.code
+        super().__post_init__()
+
+    @classmethod
+    def type_factory(cls, header: MessageHeader) -> Type[_AnyMessageType] | None:
+        if header.is_request:
+            return RegistrationTerminationRequest
+        return RegistrationTerminationAnswer
+
+
+class RegistrationTerminationAnswer(RegistrationTermination):
+    """A Registration-Termination-Answer message."""
+    session_id: str
+    drmp: int
+    vendor_specific_application_id: VendorSpecificApplicationId
+    result_code: int
+    experimental_result: ExperimentalResult
+    auth_session_state: int
+    origin_host: bytes
+    origin_realm: bytes
+    associated_identities: AssociatedIdentities
+    supported_features: list[SupportedFeatures]
+    identity_with_emergency_registration: list[IdentityWithEmergencyRegistration]
+    failed_avp: list[FailedAvp]
+    proxy_info: list[ProxyInfo]
+    route_record: list[bytes]
+
+    avp_def: AvpGenType = (
+        AvpGenDef("session_id", AVP_SESSION_ID, is_required=True),
+        AvpGenDef("drmp", AVP_DRMP),
+        AvpGenDef("vendor_specific_application_id", AVP_VENDOR_SPECIFIC_APPLICATION_ID, is_required=True, type_class=VendorSpecificApplicationId),
+        AvpGenDef("result_code", AVP_RESULT_CODE),
+        AvpGenDef("experimental_result", AVP_EXPERIMENTAL_RESULT, type_class=ExperimentalResult),
+        AvpGenDef("auth_session_state", AVP_AUTH_SESSION_STATE, is_required=True),
+        AvpGenDef("origin_host", AVP_ORIGIN_HOST, is_required=True),
+        AvpGenDef("origin_realm", AVP_ORIGIN_REALM, is_required=True),
+        AvpGenDef("associated_identities", AVP_TGPP_ASSOCIATED_IDENTITIES, VENDOR_TGPP, type_class=AssociatedIdentities),
+        AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
+        AvpGenDef("identity_with_emergency_registration", AVP_TGPP_IDENTITY_WITH_EMERGENCY_REGISTRATION, VENDOR_TGPP, type_class=IdentityWithEmergencyRegistration),
+        AvpGenDef("failed_avp", AVP_FAILED_AVP, type_class=FailedAvp),
+        AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
+        AvpGenDef("route_record", AVP_ROUTE_RECORD)
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.header.is_request = False
+        self.header.is_proxyable = True
+
+        setattr(self, "supported_features", [])
+        setattr(self, "identity_with_emergency_registration", [])
+        setattr(self, "failed_avp", [])
+        setattr(self, "proxy_info", [])
+        setattr(self, "route_record", [])
+
+        assign_attr_from_defs(self, self._avps)
+        self._avps = []
+
+
+class RegistrationTerminationRequest(RegistrationTermination):
+    """A Registration-Termination-Request message."""
+    session_id: str
+    drmp: int
+    vendor_specific_application_id: VendorSpecificApplicationId
+    auth_session_state: int
+    origin_host: bytes
+    origin_realm: bytes
+    destination_host: bytes
+    destination_realm: bytes
+    user_name: str
+    associated_identities: AssociatedIdentities
+    supported_features: list[SupportedFeatures]
+    public_identity: list[str]
+    deregistration_reason: DeregistrationReason
+    proxy_info: list[ProxyInfo]
+    route_record: list[bytes]
+
+    avp_def: AvpGenType = (
+        AvpGenDef("session_id", AVP_SESSION_ID, is_required=True),
+        AvpGenDef("drmp", AVP_DRMP),
+        AvpGenDef("vendor_specific_application_id", AVP_VENDOR_SPECIFIC_APPLICATION_ID, is_required=True, type_class=VendorSpecificApplicationId),
+        AvpGenDef("auth_session_state", AVP_AUTH_SESSION_STATE, is_required=True),
+        AvpGenDef("origin_host", AVP_ORIGIN_HOST, is_required=True),
+        AvpGenDef("origin_realm", AVP_ORIGIN_REALM, is_required=True),
+        AvpGenDef("destination_host", AVP_DESTINATION_HOST, is_required=True),
+        AvpGenDef("destination_realm", AVP_DESTINATION_REALM, is_required=True),
+        AvpGenDef("user_name", AVP_USER_NAME, is_required=True),
+        AvpGenDef("associated_identities", AVP_TGPP_ASSOCIATED_IDENTITIES, VENDOR_TGPP, type_class=AssociatedIdentities),
+        AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
+        AvpGenDef("public_identity", AVP_TGPP_PUBLIC_IDENTITY, VENDOR_TGPP, is_required=True),
+        AvpGenDef("deregistration_reason", AVP_TGPP_DEREGISTRATION_REASON, VENDOR_TGPP, is_required=True, type_class=DeregistrationReason),
+        AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
+        AvpGenDef("route_record", AVP_ROUTE_RECORD)
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.header.is_request = True
+        self.header.is_proxyable = True
+
+        setattr(self, "supported_features", [])
+        setattr(self, "public_identity", [])
+        setattr(self, "proxy_info", [])
+        setattr(self, "route_record", [])
+
+        assign_attr_from_defs(self, self._avps)
+        self._avps = []

--- a/src/diameter/message/commands/server_assignment.py
+++ b/src/diameter/message/commands/server_assignment.py
@@ -1,0 +1,218 @@
+"""
+Diameter Cx/Dx Interface.
+
+This module contains Server Assignment Request and Answer messages,
+implementing AVPs documented in 3GPP TS 29.229.
+"""
+from __future__ import annotations
+
+from typing import Type
+
+from .._base import Message, MessageHeader, DefinedMessage, _AnyMessageType
+from ..avp.grouped import *
+from ..avp.generator import AvpGenDef, AvpGenType
+from ._attributes import assign_attr_from_defs
+
+
+__all__ = ["ServerAssignment", "ServerAssignmentAnswer", "ServerAssignmentRequest"]
+
+
+class ServerAssignment(DefinedMessage):
+    """A Server-Assignment base message.
+
+    This message class lists message attributes based on the current 3GPP TS
+    29.229 version 13.1.0 Release 13 as python properties, accessible as
+    instance attributes. AVPs not listed in the spec protocol can be
+    retrieved using the
+    [ServerAssignment.find_avps][diameter.message.Message.find_avps] search
+    method.
+
+    Examples:
+        AVPs accessible either as instance attributes or by searching:
+
+        >>> msg = Message.from_bytes(b"...")
+        >>> msg.session_id
+        dra1.mvno.net;2323;546
+        >>> msg.find_avps((AVP_SESSION_ID, 0))
+        ['dra1.mvno.net;2323;546']
+
+        When diameter message is decoded using
+        [Message.from_bytes][diameter.message.Message.from_bytes], it returns
+        either an instance of `ServerAssignmentRequest` or
+        `ServerAssignmentAnswer` automatically:
+
+        >>> msg = Message.from_bytes(b"...")
+        >>> assert msg.header.is_request is True
+        >>> assert isinstance(msg, ServerAssignmentRequest)
+
+        When creating a new message, the `ServerAssignmentRequest` or
+        `ServerAssignmentAnswer` class should be instantiated directly, and
+        values for AVPs set as class attributes:
+
+        >>> msg = ServerAssignmentRequest()
+        >>> msg.session_id = "dra1.mvno.net;2323;546"
+
+    Other, custom AVPs can be appended to the message using the
+    [ServerAssignment.append_avp][diameter.message.Message.append_avp] method,
+    or by overwriting the `avp` attribute entirely. Regardless of the custom
+    AVPs set, the mandatory values listed in TS 29.229 must be set, however
+    they can be set as `None`, if they are not to be used.
+
+    !!! Warning
+        Every AVP documented for the subclasses of this command can be accessed
+        as an instance attribute, even if the original network-received message
+        did not contain that specific AVP. Such AVPs will be returned with the
+        value `None` when accessed.
+
+        Every other AVP not mentioned here, and not present in a
+        network-received message will raise an `AttributeError` when being
+        accessed; their presence should be validated with `hasattr` before
+        accessing.
+
+    """
+    code: int = 301
+    name: str = "Server-Assignment"
+    avp_def: AvpGenType
+
+    def __post_init__(self):
+        self.header.command_code = self.code
+        super().__post_init__()
+
+    @classmethod
+    def type_factory(cls, header: MessageHeader) -> Type[_AnyMessageType] | None:
+        if header.is_request:
+            return ServerAssignmentRequest
+        return ServerAssignmentAnswer
+
+
+class ServerAssignmentAnswer(ServerAssignment):
+    """A Server-Assignment-Answer message."""
+    session_id: str
+    drmp: int
+    vendor_specific_application_id: VendorSpecificApplicationId
+    result_code: int
+    experimental_result: ExperimentalResult
+    auth_session_state: int
+    origin_host: bytes
+    origin_realm: bytes
+    oc_supported_features: OcSupportedFeatures
+    oc_olr: OcOlr
+    supported_features: list[SupportedFeatures]
+    user_data: bytes
+    charging_information: ChargingInformation
+    associated_identities: AssociatedIdentities
+    loose_route_indication: int
+    scscf_restoration_info: list[ScscfRestorationInfo]
+    associated_registered_identities: AssociatedRegisteredIdentities
+    server_name: str
+    wildcarded_public_identity: str
+    privileged_sender_indication: int
+    allowed_waf_wwsf_identities: AllowedWafWwsfIdentities
+    failed_avp: list[FailedAvp]
+    proxy_info: list[ProxyInfo]
+    route_record: list[bytes]
+
+    avp_def: AvpGenType = (
+        AvpGenDef("session_id", AVP_SESSION_ID, is_required=True),
+        AvpGenDef("drmp", AVP_DRMP),
+        AvpGenDef("vendor_specific_application_id", AVP_VENDOR_SPECIFIC_APPLICATION_ID, is_required=True, type_class=VendorSpecificApplicationId),
+        AvpGenDef("result_code", AVP_RESULT_CODE),
+        AvpGenDef("experimental_result", AVP_EXPERIMENTAL_RESULT, type_class=ExperimentalResult),
+        AvpGenDef("auth_session_state", AVP_AUTH_SESSION_STATE),
+        AvpGenDef("origin_host", AVP_ORIGIN_HOST, is_required=True),
+        AvpGenDef("origin_realm", AVP_ORIGIN_REALM, is_required=True),
+        AvpGenDef("oc_supported_features", AVP_OC_SUPPORTED_FEATURES, type_class=OcSupportedFeatures),
+        AvpGenDef("oc_olr", AVP_OC_OLR, type_class=OcOlr),
+        AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
+        AvpGenDef("user_data", AVP_TGPP_CX_USER_DATA, VENDOR_TGPP),
+        AvpGenDef("charging_information", AVP_TGPP_CHARGING_INFORMATION, VENDOR_TGPP, type_class=ChargingInformation),
+        AvpGenDef("associated_identities", AVP_TGPP_ASSOCIATED_IDENTITIES, VENDOR_TGPP, type_class=AssociatedIdentities),
+        AvpGenDef("loose_route_indication", AVP_TGPP_LOOSE_ROUTE_INDICATION, VENDOR_TGPP),
+        AvpGenDef("scscf_restoration_info", AVP_TGPP_SCSCF_RESTORATION_INFO, VENDOR_TGPP, type_class=ScscfRestorationInfo),
+        AvpGenDef("associated_registered_identities", AVP_TGPP_ASSOCIATED_REGISTERED_IDENTITIES, VENDOR_TGPP, type_class=AssociatedRegisteredIdentities),
+        AvpGenDef("server_name", AVP_TGPP_SERVER_NAME, VENDOR_TGPP),
+        AvpGenDef("wildcarded_public_identity", AVP_TGPP_WILDCARDED_PSI, VENDOR_TGPP),
+        AvpGenDef("privileged_sender_indication", AVP_TGPP_PRIVILEDGED_SENDER_INDICATION, VENDOR_TGPP),
+        AvpGenDef("allowed_waf_wwsf_identities", AVP_TGPP_ALLOWED_WAF_WWSF_IDENTITIES, VENDOR_TGPP, type_class=AllowedWafWwsfIdentities),
+        AvpGenDef("failed_avp", AVP_FAILED_AVP, type_class=FailedAvp),
+        AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
+        AvpGenDef("route_record", AVP_ROUTE_RECORD)
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.header.is_request = False
+        self.header.is_proxyable = True
+
+        setattr(self, "supported_features", [])
+        setattr(self, "scscf_restoration_info", [])
+        setattr(self, "failed_avp", [])
+        setattr(self, "proxy_info", [])
+        setattr(self, "route_record", [])
+
+        assign_attr_from_defs(self, self._avps)
+        self._avps = []
+
+
+class ServerAssignmentRequest(ServerAssignment):
+    """A Server-Assignment-Request message."""
+    session_id: str
+    drmp: int
+    vendor_specific_application_id: VendorSpecificApplicationId
+    auth_session_state: int
+    origin_host: bytes
+    origin_realm: bytes
+    destination_host: bytes
+    destination_realm: bytes
+    user_name: str
+    oc_supported_features: OcSupportedFeatures
+    supported_features: list[SupportedFeatures]
+    public_identity: list[str]
+    wildcarded_public_identity: str
+    server_name: str
+    server_assignment_type: int
+    user_data_already_available: int
+    scscf_restoration_info: ScscfRestorationInfo
+    multiple_registration_indication: int
+    session_priority: int
+    sar_flags: int
+    proxy_info: list[ProxyInfo]
+    route_record: list[bytes]
+
+    avp_def: AvpGenType = (
+        AvpGenDef("session_id", AVP_SESSION_ID, is_required=True),
+        AvpGenDef("drmp", AVP_DRMP),
+        AvpGenDef("vendor_specific_application_id", AVP_VENDOR_SPECIFIC_APPLICATION_ID, is_required=True, type_class=VendorSpecificApplicationId),
+        AvpGenDef("auth_session_state", AVP_AUTH_SESSION_STATE, is_required=True),
+        AvpGenDef("origin_host", AVP_ORIGIN_HOST, is_required=True),
+        AvpGenDef("origin_realm", AVP_ORIGIN_REALM, is_required=True),
+        AvpGenDef("destination_host", AVP_DESTINATION_HOST),
+        AvpGenDef("destination_realm", AVP_DESTINATION_REALM, is_required=True),
+        AvpGenDef("user_name", AVP_USER_NAME, is_required=True),
+        AvpGenDef("oc_supported_features", AVP_OC_SUPPORTED_FEATURES, type_class=OcSupportedFeatures),
+        AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
+        AvpGenDef("public_identity", AVP_TGPP_PUBLIC_IDENTITY, VENDOR_TGPP),
+        AvpGenDef("wildcarded_public_identity", AVP_TGPP_WILDCARDED_PSI, VENDOR_TGPP),
+        AvpGenDef("server_name", AVP_TGPP_SERVER_NAME, VENDOR_TGPP, is_required=True),
+        AvpGenDef("server_assignment_type", AVP_TGPP_SERVER_ASSIGNMENT_TYPE, VENDOR_TGPP, is_required=True),
+        AvpGenDef("user_data_already_available", AVP_TGPP_USER_DATA_ALREADY_AVAILABLE, VENDOR_TGPP, is_required=True),
+        AvpGenDef("scscf_restoration_info", AVP_TGPP_SCSCF_RESTORATION_INFO, VENDOR_TGPP, type_class=ScscfRestorationInfo),
+        AvpGenDef("multiple_registration_indication", AVP_TGPP_MULTIPLE_REGISTRATION_INDICATION, VENDOR_TGPP),
+        AvpGenDef("session_priority", AVP_TGPP_SESSION_PRIORITY, VENDOR_TGPP),
+        AvpGenDef("sar_flags", AVP_TGPP_SAR_FLAGS, VENDOR_TGPP),
+        AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
+        AvpGenDef("route_record", AVP_ROUTE_RECORD)
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.header.is_request = True
+        self.header.is_proxyable = True
+
+        setattr(self, "supported_features", [])
+        setattr(self, "public_identity", [])
+        setattr(self, "proxy_info", [])
+        setattr(self, "route_record", [])
+
+        assign_attr_from_defs(self, self._avps)
+        self._avps = []

--- a/src/diameter/message/commands/user_authorization.py
+++ b/src/diameter/message/commands/user_authorization.py
@@ -1,0 +1,186 @@
+"""
+Diameter Cx/Dx Interface.
+
+This module contains User Authorization Request and Answer messages,
+implementing AVPs documented in 3GPP TS 29.229.
+"""
+from __future__ import annotations
+
+from typing import Type
+
+from .._base import Message, MessageHeader, DefinedMessage, _AnyMessageType
+from ..avp.grouped import *
+from ..avp.generator import AvpGenDef, AvpGenType
+from ._attributes import assign_attr_from_defs
+
+
+__all__ = ["UserAuthorization", "UserAuthorizationAnswer", "UserAuthorizationRequest"]
+
+
+class UserAuthorization(DefinedMessage):
+    """A User-Authorization base message.
+
+    This message class lists message attributes based on the current 3GPP TS 
+    29.229 version 13.1.0 Release 13 as python properties, accessible as
+    instance attributes. AVPs not listed in the spec protocol can be
+    retrieved using the 
+    [UserAuthorization.find_avps][diameter.message.Message.find_avps] search
+    method.
+
+    Examples:
+        AVPs accessible either as instance attributes or by searching:
+
+        >>> msg = Message.from_bytes(b"...")
+        >>> msg.session_id
+        dra1.mvno.net;2323;546
+        >>> msg.find_avps((AVP_SESSION_ID, 0))
+        ['dra1.mvno.net;2323;546']
+
+        When diameter message is decoded using
+        [Message.from_bytes][diameter.message.Message.from_bytes], it returns
+        either an instance of `UserAuthorizationRequest` or
+        `UserAuthorizationAnswer` automatically:
+
+        >>> msg = Message.from_bytes(b"...")
+        >>> assert msg.header.is_request is True
+        >>> assert isinstance(msg, UserAuthorizationRequest)
+
+        When creating a new message, the `UserAuthorizationRequest` or
+        `UserAuthorizationAnswer` class should be instantiated directly, and
+        values for AVPs set as class attributes:
+
+        >>> msg = UserAuthorizationRequest()
+        >>> msg.session_id = "dra1.mvno.net;2323;546"
+
+    Other, custom AVPs can be appended to the message using the
+    [UserAuthorization.append_avp][diameter.message.Message.append_avp] method,
+    or by overwriting the `avp` attribute entirely. Regardless of the custom
+    AVPs set, the mandatory values listed in TS 29.229 must be set, however
+    they can be set as `None`, if they are not to be used.
+
+    !!! Warning
+        Every AVP documented for the subclasses of this command can be accessed
+        as an instance attribute, even if the original network-received message
+        did not contain that specific AVP. Such AVPs will be returned with the
+        value `None` when accessed.
+
+        Every other AVP not mentioned here, and not present in a
+        network-received message will raise an `AttributeError` when being
+        accessed; their presence should be validated with `hasattr` before
+        accessing.
+
+    """
+    code: int = 300
+    name: str = "User-Authorization"
+    avp_def: AvpGenType
+
+    def __post_init__(self):
+        self.header.command_code = self.code
+        super().__post_init__()
+
+    @classmethod
+    def type_factory(cls, header: MessageHeader) -> Type[_AnyMessageType] | None:
+        if header.is_request:
+            return UserAuthorizationRequest
+        return UserAuthorizationAnswer
+
+
+class UserAuthorizationAnswer(UserAuthorization):
+    """A User-Authorization-Answer message."""
+    session_id: str
+    drmp: int
+    vendor_specific_application_id: VendorSpecificApplicationId
+    result_code: int
+    experimental_result: ExperimentalResult
+    auth_session_state: int
+    origin_host: bytes
+    origin_realm: bytes
+    oc_supported_features: OcSupportedFeatures
+    oc_olr: OcOlr
+    supported_features: list[SupportedFeatures]
+    server_name: str
+    server_capabilities: ServerCapabilities
+    failed_avp: list[FailedAvp]
+    proxy_info: list[ProxyInfo]
+    route_record: list[bytes]
+
+    avp_def: AvpGenType = (
+        AvpGenDef("session_id", AVP_SESSION_ID, is_required=True),
+        AvpGenDef("drmp", AVP_DRMP),
+        AvpGenDef("vendor_specific_application_id", AVP_VENDOR_SPECIFIC_APPLICATION_ID, is_required=True, type_class=VendorSpecificApplicationId),
+        AvpGenDef("result_code", AVP_RESULT_CODE),
+        AvpGenDef("experimental_result", AVP_EXPERIMENTAL_RESULT, type_class=ExperimentalResult),
+        AvpGenDef("auth_session_state", AVP_AUTH_SESSION_STATE),
+        AvpGenDef("origin_host", AVP_ORIGIN_HOST, is_required=True),
+        AvpGenDef("origin_realm", AVP_ORIGIN_REALM, is_required=True),
+        AvpGenDef("oc_supported_features", AVP_OC_SUPPORTED_FEATURES, type_class=OcSupportedFeatures),
+        AvpGenDef("oc_olr", AVP_OC_OLR, type_class=OcOlr),
+        AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
+        AvpGenDef("server_name", AVP_TGPP_SERVER_NAME, VENDOR_TGPP),
+        AvpGenDef("server_capabilities", AVP_TGPP_SERVER_CAPABILITIES, VENDOR_TGPP, type_class=ServerCapabilities),
+        AvpGenDef("failed_avp", AVP_FAILED_AVP, type_class=FailedAvp),
+        AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
+        AvpGenDef("route_record", AVP_ROUTE_RECORD)
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.header.is_request = False
+        self.header.is_proxyable = True
+
+        setattr(self, "supported_features", [])
+        setattr(self, "failed_avp", [])
+        setattr(self, "proxy_info", [])
+        setattr(self, "route_record", [])
+
+        assign_attr_from_defs(self, self._avps)
+        self._avps = []
+
+
+class UserAuthorizationRequest(UserAuthorization):
+    """A User-Authorization-Request message."""
+    vendor_specific_application_id: VendorSpecificApplicationId
+    auth_session_state: int
+    origin_host: bytes
+    origin_realm: bytes
+    destination_host: bytes
+    destination_realm: bytes
+    user_name: str
+    oc_supported_features: OcSupportedFeatures
+    supported_features: list[SupportedFeatures]
+    public_identity: str
+    visited_network_identifier: bytes
+    user_authorization_type: int
+    uar_flags: int
+    proxy_info: list[ProxyInfo]
+    route_record: list[bytes]
+
+    avp_def: AvpGenType = (
+        AvpGenDef("vendor_specific_application_id", AVP_VENDOR_SPECIFIC_APPLICATION_ID, is_required=True, type_class=VendorSpecificApplicationId),
+        AvpGenDef("auth_session_state", AVP_AUTH_SESSION_STATE, is_required=True),
+        AvpGenDef("origin_host", AVP_ORIGIN_HOST, is_required=True),
+        AvpGenDef("origin_realm", AVP_ORIGIN_REALM, is_required=True),
+        AvpGenDef("destination_host", AVP_DESTINATION_HOST),
+        AvpGenDef("destination_realm", AVP_DESTINATION_REALM, is_required=True),
+        AvpGenDef("user_name", AVP_USER_NAME, is_required=True),
+        AvpGenDef("oc_supported_features", AVP_OC_SUPPORTED_FEATURES, type_class=OcSupportedFeatures),
+        AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
+        AvpGenDef("public_identity", AVP_TGPP_PUBLIC_IDENTITY, VENDOR_TGPP, is_required=True),
+        AvpGenDef("visited_network_identifier", AVP_TGPP_VISITED_NETWORK_IDENTIFIER, VENDOR_TGPP, is_required=True),
+        AvpGenDef("user_authorization_type", AVP_TGPP_USER_AUTHORIZATION_TYPE, VENDOR_TGPP),
+        AvpGenDef("uar_flags", AVP_TGPP_UAR_FLAGS, VENDOR_TGPP),
+        AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
+        AvpGenDef("route_record", AVP_ROUTE_RECORD)
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.header.is_request = True
+        self.header.is_proxyable = True
+
+        setattr(self, "supported_features", [])
+        setattr(self, "proxy_info", [])
+        setattr(self, "route_record", [])
+
+        assign_attr_from_defs(self, self._avps)
+        self._avps = []

--- a/tests/test_location_info.py
+++ b/tests/test_location_info.py
@@ -1,0 +1,142 @@
+"""
+Run from package root:
+~# python3 -m pytest -vv
+"""
+import pytest
+
+from diameter.message import constants
+from diameter.message.avp import Avp
+from diameter.message.commands import LocationInfoAnswer, LocationInfoRequest
+from diameter.message.commands.location_info import ExperimentalResult
+from diameter.message.commands.location_info import FailedAvp
+from diameter.message.commands.location_info import OcOlr
+from diameter.message.commands.location_info import OcSupportedFeatures
+from diameter.message.commands.location_info import ProxyInfo
+from diameter.message.commands.location_info import ServerCapabilities
+from diameter.message.commands.location_info import SipAuthDataItem
+from diameter.message.commands.location_info import SipDigestAuthenticate
+from diameter.message.commands.location_info import SupportedFeatures
+from diameter.message.commands.location_info import VendorSpecificApplicationId
+
+
+def test_lir_create_new():
+    # build a location-info-request with every attribute populated and
+    # attempt to parse it
+    lir = LocationInfoRequest()
+    lir.session_id = "ims1.epc.mnc001.mcc228.3gppnetwork.org;1744321200;499694;196056826"
+    lir.drmp = constants.E_DRMP_PRIORITY_0
+    lir.vendor_specific_application_id = VendorSpecificApplicationId(
+        vendor_id=constants.VENDOR_TGPP,
+        auth_application_id=constants.APP_3GPP_CX,
+        acct_application_id=constants.APP_3GPP_CX
+    )
+    # TS 29.229 version 13.1.0 Chapter 5.3
+    lir.auth_session_state = constants.E_AUTH_SESSION_STATE_NO_STATE_MAINTAINED
+    lir.origin_host = b"ims1.epc.mnc001.mcc228.3gppnetwork.org"
+    lir.origin_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    lir.destination_host = b"hss1.epc.mnc001.mcc228.3gppnetwork.org"
+    lir.destination_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    lir.user_name = "228011000127286@ims.mnc001.mcc228.3gppnetwork.org"
+    lir.oc_supported_features = OcSupportedFeatures(
+        oc_feature_vector=0
+    )
+    lir.supported_features = [SupportedFeatures(
+        vendor_id=constants.VENDOR_TGPP,
+        feature_list_id=0,
+        feature_list=1
+    )]
+    lir.public_identity = "sip:228011000127286@ims.mnc001.mcc228.3gppnetwork.org"
+    lir.sip_auth_data_item = SipAuthDataItem(
+        sip_item_number=0,
+        sip_authentication_scheme=constants.E_SIP_AUTHENTICATION_SCHEME_DIGEST,
+        sip_authenticate=b"\x00\x00",
+        sip_authorization=b"\x00\x00",
+        sip_authentication_context=b"\x00\x00",
+        confidentiality_key=b"\x00\x00",
+        integrity_key=b"\x00\x00",
+        sip_digest_authenticate=SipDigestAuthenticate(
+            digest_realm="ims.mnc001.mcc228.3gppnetwork.org",
+            digest_algorithm="digest",
+            digest_qop="1",
+            digest_ha1="1",
+        ),
+        framed_ip_address=b"*\x00\x1f\xa2\xc8c\x8c~",
+        framed_ipv6_prefix=b"\x00\x00\x00a@\x00\x00\x12\x00@*\x00\x1f\xa2\xc8c\x8c~\x00\x00",
+        framed_interface_id=0,
+        line_identifier=[b"\x00\x00"],
+    )
+    lir.sip_number_auth_items = 1
+    lir.server_name = "sip:ims.mnc001.mcc228.3gppnetwork.org"
+    lir.proxy_info = [ProxyInfo(
+        proxy_host=b"swlab.roam.server.net",
+        proxy_state=b"\x00\x00"
+    )]
+    lir.route_record = [b"dra1.route.realm"]
+    msg = lir.as_bytes()
+
+    assert lir.header.length == len(msg)
+    assert lir.header.is_request is True
+
+
+def test_lia_create_new():
+    # build a location-info-answer with every attribute populated and
+    # attempt to parse it
+    lia = LocationInfoAnswer()
+    lia.session_id = "ims1.epc.mnc001.mcc228.3gppnetwork.org;1744321200;499694;196056826"
+    lia.drmp = constants.E_DRMP_PRIORITY_0
+    lia.vendor_specific_application_id = VendorSpecificApplicationId(
+        vendor_id=constants.VENDOR_TGPP,
+        auth_application_id=constants.APP_3GPP_CX,
+        acct_application_id=constants.APP_3GPP_CX
+    )
+    lia.result_code = constants.E_RESULT_CODE_DIAMETER_SUCCESS
+    lia.experimental_result = ExperimentalResult(
+        vendor_id=constants.VENDOR_TGPP,
+        experimental_result_code=constants.E_RESULT_CODE_DIAMETER_SUCCESS
+    )
+    lia.auth_session_state = constants.E_AUTH_SESSION_STATE_NO_STATE_MAINTAINED
+    lia.origin_host = b"hss1.epc.mnc001.mcc228.3gppnetwork.org"
+    lia.origin_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    lia.oc_supported_features = OcSupportedFeatures(
+        oc_feature_vector=0
+    )
+    lia.oc_olr = OcOlr(
+        oc_sequence_number=1,
+        oc_report_type=constants.E_OC_REPORT_TYPE_HOST_REPORT,
+        oc_reduction_percentage=1,
+        oc_validity_duration=1
+    )
+    lia.supported_features = [SupportedFeatures(
+        vendor_id=constants.VENDOR_TGPP,
+        feature_list_id=0,
+        feature_list=1
+    )]
+    lia.server_name = "sip:ims.mnc001.mcc228.3gppnetwork.org"
+    lia.server_capabilities = ServerCapabilities(
+        mandatory_capability=[0],
+        optional_capability=[1],
+        server_name=["name"]
+    )
+    lia.wildcarded_public_identity = "sip:*@ims.mnc001.mcc228.3gppnetwork.org"
+    lia.lia_flags = 0
+    lia.failed_avp = [FailedAvp(additional_avps=[
+        Avp.new(constants.AVP_ORIGIN_HOST, value=b"dra1.local.realm")
+    ])]
+    lia.proxy_info = [ProxyInfo(
+        proxy_host=b"swlab.roam.server.net",
+        proxy_state=b"\x00\x00"
+    )]
+    lia.route_record = [b"dra1.route.realm"]
+
+    msg = lia.as_bytes()
+
+    assert lia.header.length == len(msg)
+    assert lia.header.is_request is False
+
+
+def test_lir_to_lia():
+    req = LocationInfoRequest()
+    ans = req.to_answer()
+
+    assert isinstance(ans, LocationInfoAnswer)
+    assert ans.header.is_request is False

--- a/tests/test_multimedia_auth.py
+++ b/tests/test_multimedia_auth.py
@@ -1,0 +1,154 @@
+"""
+Run from the package root:
+~# python3 -m pytest -vv
+"""
+import pytest
+
+from diameter.message import constants
+from diameter.message.avp import Avp
+from diameter.message.commands import MultimediaAuthAnswer, MultimediaAuthRequest
+from diameter.message.commands.multimedia_auth import ExperimentalResult
+from diameter.message.commands.multimedia_auth import FailedAvp
+from diameter.message.commands.multimedia_auth import OcOlr
+from diameter.message.commands.multimedia_auth import OcSupportedFeatures
+from diameter.message.commands.multimedia_auth import ProxyInfo
+from diameter.message.commands.multimedia_auth import SipAuthDataItem
+from diameter.message.commands.multimedia_auth import SipDigestAuthenticate
+from diameter.message.commands.multimedia_auth import SupportedFeatures
+from diameter.message.commands.multimedia_auth import VendorSpecificApplicationId
+
+
+def test_mar_create_new():
+    # build a multimedia-auth-request with every attribute populated and
+    # attempt to parse it
+    mar = MultimediaAuthRequest()
+    mar.session_id = "ims1.epc.mnc001.mcc228.3gppnetwork.org;1744321200;499694;196056826"
+    mar.drmp = constants.E_DRMP_PRIORITY_0
+    mar.vendor_specific_application_id = VendorSpecificApplicationId(
+        vendor_id=constants.VENDOR_TGPP,
+        auth_application_id=constants.APP_3GPP_CX,
+        acct_application_id=constants.APP_3GPP_CX
+    )
+    # TS 29.229 version 13.1.0 Chapter 5.3
+    mar.auth_session_state = constants.E_AUTH_SESSION_STATE_NO_STATE_MAINTAINED
+    mar.origin_host = b"ims1.epc.mnc001.mcc228.3gppnetwork.org"
+    mar.origin_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    mar.destination_host = b"hss1.epc.mnc001.mcc228.3gppnetwork.org"
+    mar.destination_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    mar.user_name = "228011000127286@ims.mnc001.mcc228.3gppnetwork.org"
+    mar.oc_supported_features = OcSupportedFeatures(
+        oc_feature_vector=0
+    )
+    mar.supported_features = [SupportedFeatures(
+        vendor_id=constants.VENDOR_TGPP,
+        feature_list_id=0,
+        feature_list=1
+    )]
+    mar.public_identity = ["sip:228011000127286@ims.mnc001.mcc228.3gppnetwork.org"]
+    mar.sip_auth_data_item = SipAuthDataItem(
+        sip_item_number=0,
+        sip_authentication_scheme=constants.E_SIP_AUTHENTICATION_SCHEME_DIGEST,
+        sip_authenticate=b"\x00\x00",
+        sip_authorization=b"\x00\x00",
+        sip_authentication_context=b"\x00\x00",
+        confidentiality_key=b"\x00\x00",
+        integrity_key=b"\x00\x00",
+        sip_digest_authenticate=SipDigestAuthenticate(
+            digest_realm="ims.mnc001.mcc228.3gppnetwork.org",
+            digest_algorithm="digest",
+            digest_qop="1",
+            digest_ha1="1",
+        ),
+        framed_ip_address=b"*\x00\x1f\xa2\xc8c\x8c~",
+        framed_ipv6_prefix=b"\x00\x00\x00a@\x00\x00\x12\x00@*\x00\x1f\xa2\xc8c\x8c~\x00\x00",
+        framed_interface_id=0,
+        line_identifier=[b"\x00\x00"],
+    )
+    mar.sip_number_auth_items = 1
+    mar.server_name = "sip:ims.mnc001.mcc228.3gppnetwork.org"
+    mar.proxy_info = [ProxyInfo(
+        proxy_host=b"swlab.roam.server.net",
+        proxy_state=b"\x00\x00"
+    )]
+    mar.route_record = [b"dra1.route.realm"]
+    msg = mar.as_bytes()
+
+    assert mar.header.length == len(msg)
+    assert mar.header.is_request is True
+
+
+def test_maa_create_new():
+    # build a multimedia-auth-answer with every attribute populated and
+    # attempt to parse it
+    maa = MultimediaAuthAnswer()
+    maa.session_id = "ims1.epc.mnc001.mcc228.3gppnetwork.org;1744321200;499694;196056826"
+    maa.drmp = constants.E_DRMP_PRIORITY_0
+    maa.vendor_specific_application_id = VendorSpecificApplicationId(
+        vendor_id=constants.VENDOR_TGPP,
+        auth_application_id=constants.APP_3GPP_CX,
+        acct_application_id=constants.APP_3GPP_CX
+    )
+    maa.result_code = constants.E_RESULT_CODE_DIAMETER_SUCCESS
+    maa.experimental_result = ExperimentalResult(
+        vendor_id=constants.VENDOR_TGPP,
+        experimental_result_code=constants.E_RESULT_CODE_DIAMETER_SUCCESS
+    )
+    maa.auth_session_state = constants.E_AUTH_SESSION_STATE_NO_STATE_MAINTAINED
+    maa.origin_host = b"hss1.epc.mnc001.mcc228.3gppnetwork.org"
+    maa.origin_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    maa.oc_supported_features = OcSupportedFeatures(
+        oc_feature_vector=0
+    )
+    maa.oc_olr = OcOlr(
+        oc_sequence_number=1,
+        oc_report_type=constants.E_OC_REPORT_TYPE_HOST_REPORT,
+        oc_reduction_percentage=1,
+        oc_validity_duration=1
+    )
+    maa.supported_features = [SupportedFeatures(
+        vendor_id=constants.VENDOR_TGPP,
+        feature_list_id=0,
+        feature_list=1
+    )]
+    maa.public_identity = "sip:228011000127286@ims.mnc001.mcc228.3gppnetwork.org"
+    maa.sip_auth_data_item = [SipAuthDataItem(
+        sip_item_number=0,
+        sip_authentication_scheme=constants.E_SIP_AUTHENTICATION_SCHEME_DIGEST,
+        sip_authenticate=b"\x00\x00",
+        sip_authorization=b"\x00\x00",
+        sip_authentication_context=b"\x00\x00",
+        confidentiality_key=b"\x00\x00",
+        integrity_key=b"\x00\x00",
+        sip_digest_authenticate=SipDigestAuthenticate(
+            digest_realm="ims.mnc001.mcc228.3gppnetwork.org",
+            digest_algorithm="digest",
+            digest_qop="1",
+            digest_ha1="1",
+        ),
+        framed_ip_address=b"*\x00\x1f\xa2\xc8c\x8c~",
+        framed_ipv6_prefix=b"\x00\x00\x00a@\x00\x00\x12\x00@*\x00\x1f\xa2\xc8c\x8c~\x00\x00",
+        framed_interface_id=0,
+        line_identifier=[b"\x00\x00"],
+    )]
+    maa.sip_number_auth_items = 1
+    maa.failed_avp = [FailedAvp(additional_avps=[
+        Avp.new(constants.AVP_ORIGIN_HOST, value=b"dra1.local.realm")
+    ])]
+    maa.proxy_info = [ProxyInfo(
+        proxy_host=b"swlab.roam.server.net",
+        proxy_state=b"\x00\x00"
+    )]
+    maa.route_record = [b"dra1.route.realm"]
+
+    msg = maa.as_bytes()
+
+    assert maa.header.length == len(msg)
+    assert maa.header.is_request is False
+
+
+def test_mar_to_maa():
+    req = MultimediaAuthRequest()
+    ans = req.to_answer()
+
+    assert isinstance(ans, MultimediaAuthAnswer)
+    assert ans.header.is_request is False

--- a/tests/test_push_profile.py
+++ b/tests/test_push_profile.py
@@ -1,0 +1,128 @@
+"""
+Run from package root:
+~# python3 -m pytest -vv
+"""
+import pytest
+
+from diameter.message import constants
+from diameter.message.commands import PushProfileAnswer, PushProfileRequest
+from diameter.message.commands.push_profile import AllowedWafWwsfIdentities
+from diameter.message.commands.push_profile import ChargingInformation
+from diameter.message.commands.push_profile import ExperimentalResult
+from diameter.message.commands.push_profile import OcSupportedFeatures
+from diameter.message.commands.push_profile import ProxyInfo
+from diameter.message.commands.push_profile import SipAuthDataItem
+from diameter.message.commands.push_profile import SipDigestAuthenticate
+from diameter.message.commands.push_profile import SupportedFeatures
+from diameter.message.commands.push_profile import VendorSpecificApplicationId
+
+
+def test_ppr_create_new():
+    # build a push-profile-request with every attribute populated and
+    # attempt to parse it
+    ppr = PushProfileRequest()
+    ppr.session_id = "ims1.epc.mnc001.mcc228.3gppnetwork.org;1744321200;499694;196056826"
+    ppr.drmp = constants.E_DRMP_PRIORITY_0
+    ppr.vendor_specific_application_id = VendorSpecificApplicationId(
+        vendor_id=constants.VENDOR_TGPP,
+        auth_application_id=constants.APP_3GPP_CX,
+        acct_application_id=constants.APP_3GPP_CX
+    )
+    # TS 29.229 version 13.1.0 Chapter 5.3
+    ppr.auth_session_state = constants.E_AUTH_SESSION_STATE_NO_STATE_MAINTAINED
+    ppr.origin_host = b"ims1.epc.mnc001.mcc228.3gppnetwork.org"
+    ppr.origin_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    ppr.destination_host = b"hss1.epc.mnc001.mcc228.3gppnetwork.org"
+    ppr.destination_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    ppr.user_name = "228011000127286@ims.mnc001.mcc228.3gppnetwork.org"
+    ppr.oc_supported_features = OcSupportedFeatures(
+        oc_feature_vector=0
+    )
+    ppr.supported_features = [SupportedFeatures(
+        vendor_id=constants.VENDOR_TGPP,
+        feature_list_id=0,
+        feature_list=1
+    )]
+    ppr.user_data = b'<?xml version="1.0" encoding="UTF-8"?><IMSSubscription><PrivateID>228011000127286@ims.mnc001.mcc228.3gppnetwork.org</PrivateID></IMSSubscription>'
+    ppr.charging_information = ChargingInformation(
+        primary_event_charging_function_name="aaa://ims.mnc001.mcc228.3gppnetwork.org",
+        secondary_event_charging_function_name="aaa://ims.mnc001.mcc228.3gppnetwork.org",
+        primary_charging_collection_function_name="aaa://ims.mnc001.mcc228.3gppnetwork.org",
+        secondary_charging_collection_function_name="aaa://ims.mnc001.mcc228.3gppnetwork.org",
+    )
+    ppr.sip_auth_data_item = SipAuthDataItem(
+        sip_item_number=0,
+        sip_authentication_scheme=constants.E_SIP_AUTHENTICATION_SCHEME_DIGEST,
+        sip_authenticate=b"\x00\x00",
+        sip_authorization=b"\x00\x00",
+        sip_authentication_context=b"\x00\x00",
+        confidentiality_key=b"\x00\x00",
+        integrity_key=b"\x00\x00",
+        sip_digest_authenticate=SipDigestAuthenticate(
+            digest_realm="ims.mnc001.mcc228.3gppnetwork.org",
+            digest_algorithm="digest",
+            digest_qop="1",
+            digest_ha1="1",
+        ),
+        framed_ip_address=b"*\x00\x1f\xa2\xc8c\x8c~",
+        framed_ipv6_prefix=b"\x00\x00\x00a@\x00\x00\x12\x00@*\x00\x1f\xa2\xc8c\x8c~\x00\x00",
+        framed_interface_id=0,
+        line_identifier=[b"\x00\x00"],
+    )
+    ppr.allowed_waf_wwsf_identities = AllowedWafWwsfIdentities(
+        webrtc_authentication_function_name=[""],
+        webrtc_web_server_function_name=[""],
+    )
+    ppr.proxy_info = [ProxyInfo(
+        proxy_host=b"swlab.roam.server.net",
+        proxy_state=b"\x00\x00"
+    )]
+    ppr.route_record = [b"dra1.route.realm"]
+    msg = ppr.as_bytes()
+
+    assert ppr.header.length == len(msg)
+    assert ppr.header.is_request is True
+
+
+def test_ppa_create_new():
+    # build a push-profile-answer with every attribute populated and
+    # attempt to parse it
+    ppa = PushProfileAnswer()
+    ppa.session_id = "ims1.epc.mnc001.mcc228.3gppnetwork.org;1744321200;499694;196056826"
+    ppa.drmp = constants.E_DRMP_PRIORITY_0
+    ppa.vendor_specific_application_id = VendorSpecificApplicationId(
+        vendor_id=constants.VENDOR_TGPP,
+        auth_application_id=constants.APP_3GPP_CX,
+        acct_application_id=constants.APP_3GPP_CX
+    )
+    ppa.result_code = constants.E_RESULT_CODE_DIAMETER_SUCCESS
+    ppa.experimental_result = ExperimentalResult(
+        vendor_id=constants.VENDOR_TGPP,
+        experimental_result_code=constants.E_RESULT_CODE_DIAMETER_SUCCESS
+    )
+    ppa.auth_session_state = constants.E_AUTH_SESSION_STATE_NO_STATE_MAINTAINED
+    ppa.origin_host = b"hss1.epc.mnc001.mcc228.3gppnetwork.org"
+    ppa.origin_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    ppa.supported_features = [SupportedFeatures(
+        vendor_id=constants.VENDOR_TGPP,
+        feature_list_id=0,
+        feature_list=1
+    )]
+    ppa.proxy_info = [ProxyInfo(
+        proxy_host=b"swlab.roam.server.net",
+        proxy_state=b"\x00\x00"
+    )]
+    ppa.route_record = [b"dra1.route.realm"]
+
+    msg = ppa.as_bytes()
+
+    assert ppa.header.length == len(msg)
+    assert ppa.header.is_request is False
+
+
+def test_ppr_to_ppa():
+    req = PushProfileRequest()
+    ans = req.to_answer()
+
+    assert isinstance(ans, PushProfileAnswer)
+    assert ans.header.is_request is False

--- a/tests/test_registration_termination.py
+++ b/tests/test_registration_termination.py
@@ -1,0 +1,113 @@
+"""
+Run from package root:
+~# python3 -m pytest -vv
+"""
+import pytest
+
+from diameter.message import constants
+from diameter.message.avp import Avp
+from diameter.message.commands import RegistrationTerminationAnswer, RegistrationTerminationRequest
+from diameter.message.commands.registration_termination import AssociatedIdentities
+from diameter.message.commands.registration_termination import DeregistrationReason
+from diameter.message.commands.registration_termination import ExperimentalResult
+from diameter.message.commands.registration_termination import FailedAvp
+from diameter.message.commands.registration_termination import IdentityWithEmergencyRegistration
+from diameter.message.commands.registration_termination import ProxyInfo
+from diameter.message.commands.registration_termination import SupportedFeatures
+from diameter.message.commands.registration_termination import VendorSpecificApplicationId
+
+
+def test_rtr_create_new():
+    # build a registration-termination-request with every attribute populated and
+    # attempt to parse it
+    rtr = RegistrationTerminationRequest()
+    rtr.session_id = "ims1.epc.mnc001.mcc228.3gppnetwork.org;1744321200;499694;196056826"
+    rtr.drmp = constants.E_DRMP_PRIORITY_0
+    rtr.vendor_specific_application_id = VendorSpecificApplicationId(
+        vendor_id=constants.VENDOR_TGPP,
+        auth_application_id=constants.APP_3GPP_CX,
+        acct_application_id=constants.APP_3GPP_CX
+    )
+    # TS 29.229 version 13.1.0 Chapter 5.3
+    rtr.auth_session_state = constants.E_AUTH_SESSION_STATE_NO_STATE_MAINTAINED
+    rtr.origin_host = b"ims1.epc.mnc001.mcc228.3gppnetwork.org"
+    rtr.origin_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    rtr.destination_host = b"hss1.epc.mnc001.mcc228.3gppnetwork.org"
+    rtr.destination_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    rtr.user_name = "228011000127286@ims.mnc001.mcc228.3gppnetwork.org"
+    rtr.associated_identities = AssociatedIdentities(
+        user_name=["228011000127286@ims.mnc001.mcc228.3gppnetwork.org"]
+    )
+    rtr.supported_features = [SupportedFeatures(
+        vendor_id=constants.VENDOR_TGPP,
+        feature_list_id=0,
+        feature_list=1
+    )]
+    rtr.public_identity = ["sip:228011000127286@ims.mnc001.mcc228.3gppnetwork.org"]
+    rtr.deregistration_reason = DeregistrationReason(
+        reason_code=constants.E_REASON_CODE_PERMANENT_TERMINATION,
+        reason_info="permanent"
+    )
+    rtr.proxy_info = [ProxyInfo(
+        proxy_host=b"swlab.roam.server.net",
+        proxy_state=b"\x00\x00"
+    )]
+    rtr.route_record = [b"dra1.route.realm"]
+    msg = rtr.as_bytes()
+
+    assert rtr.header.length == len(msg)
+    assert rtr.header.is_request is True
+
+
+def test_rta_create_new():
+    # build a registration-termination-answer with every attribute populated and
+    # attempt to parse it
+    rta = RegistrationTerminationAnswer()
+    rta.session_id = "ims1.epc.mnc001.mcc228.3gppnetwork.org;1744321200;499694;196056826"
+    rta.drmp = constants.E_DRMP_PRIORITY_0
+    rta.vendor_specific_application_id = VendorSpecificApplicationId(
+        vendor_id=constants.VENDOR_TGPP,
+        auth_application_id=constants.APP_3GPP_CX,
+        acct_application_id=constants.APP_3GPP_CX
+    )
+    rta.result_code = constants.E_RESULT_CODE_DIAMETER_SUCCESS
+    rta.experimental_result = ExperimentalResult(
+        vendor_id=constants.VENDOR_TGPP,
+        experimental_result_code=constants.E_RESULT_CODE_DIAMETER_SUCCESS
+    )
+    rta.auth_session_state = constants.E_AUTH_SESSION_STATE_NO_STATE_MAINTAINED
+    rta.origin_host = b"hss1.epc.mnc001.mcc228.3gppnetwork.org"
+    rta.origin_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    rta.associated_identities = AssociatedIdentities(
+        user_name=["228011000127286@ims.mnc001.mcc228.3gppnetwork.org"]
+    )
+    rta.supported_features = [SupportedFeatures(
+        vendor_id=constants.VENDOR_TGPP,
+        feature_list_id=0,
+        feature_list=1
+    )]
+    rta.identity_with_emergency_registration = [IdentityWithEmergencyRegistration(
+        user_name="228011000127286@ims.mnc001.mcc228.3gppnetwork.org",
+        public_identity="sip:228011000127286@ims.mnc001.mcc228.3gppnetwork.org"
+    )]
+    rta.failed_avp = [FailedAvp(additional_avps=[
+        Avp.new(constants.AVP_ORIGIN_HOST, value=b"dra1.local.realm")
+    ])]
+    rta.proxy_info = [ProxyInfo(
+        proxy_host=b"swlab.roam.server.net",
+        proxy_state=b"\x00\x00"
+    )]
+    rta.route_record = [b"dra1.route.realm"]
+
+    msg = rta.as_bytes()
+
+    assert rta.header.length == len(msg)
+    assert rta.header.is_request is False
+
+
+def test_rtr_to_rta():
+    req = RegistrationTerminationRequest()
+    ans = req.to_answer()
+
+    assert isinstance(ans, RegistrationTerminationAnswer)
+    assert ans.header.is_request is False

--- a/tests/test_server_assignment.py
+++ b/tests/test_server_assignment.py
@@ -1,0 +1,180 @@
+"""
+Run from package root:
+~# python3 -m pytest -vv
+"""
+import pytest
+
+from diameter.message import constants
+from diameter.message.avp import Avp
+from diameter.message.commands import ServerAssignmentAnswer, ServerAssignmentRequest
+from diameter.message.commands.server_assignment import AllowedWafWwsfIdentities
+from diameter.message.commands.server_assignment import AssociatedIdentities
+from diameter.message.commands.server_assignment import AssociatedRegisteredIdentities
+from diameter.message.commands.server_assignment import ChargingInformation
+from diameter.message.commands.server_assignment import ExperimentalResult
+from diameter.message.commands.server_assignment import FailedAvp
+from diameter.message.commands.server_assignment import OcOlr
+from diameter.message.commands.server_assignment import OcSupportedFeatures
+from diameter.message.commands.server_assignment import ProxyInfo
+from diameter.message.commands.server_assignment import RestorationInfo
+from diameter.message.commands.server_assignment import ScscfRestorationInfo
+from diameter.message.commands.server_assignment import SubscriptionInfo
+from diameter.message.commands.server_assignment import SupportedFeatures
+from diameter.message.commands.server_assignment import VendorSpecificApplicationId
+
+
+def test_sar_create_new():
+    # build a server-assignment-request with every attribute populated and
+    # attempt to parse it
+    sar = ServerAssignmentRequest()
+    sar.session_id = "ims1.epc.mnc001.mcc228.3gppnetwork.org;1744321200;499694;196056826"
+    sar.drmp = constants.E_DRMP_PRIORITY_0
+    sar.vendor_specific_application_id = VendorSpecificApplicationId(
+        vendor_id=constants.VENDOR_TGPP,
+        auth_application_id=constants.APP_3GPP_CX,
+        acct_application_id=constants.APP_3GPP_CX
+    )
+    # TS 29.229 version 13.1.0 Chapter 5.3
+    sar.auth_session_state = constants.E_AUTH_SESSION_STATE_NO_STATE_MAINTAINED
+    sar.origin_host = b"ims1.epc.mnc001.mcc228.3gppnetwork.org"
+    sar.origin_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    sar.destination_host = b"hss1.epc.mnc001.mcc228.3gppnetwork.org"
+    sar.destination_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    sar.user_name = "228011000127286@ims.mnc001.mcc228.3gppnetwork.org"
+    sar.oc_supported_features = OcSupportedFeatures(
+        oc_feature_vector=0
+    )
+    sar.supported_features = [SupportedFeatures(
+        vendor_id=constants.VENDOR_TGPP,
+        feature_list_id=0,
+        feature_list=1
+    )]
+    sar.public_identity = ["sip:228011000127286@ims.mnc001.mcc228.3gppnetwork.org"]
+    sar.wildcarded_public_identity = "sip:*@ims.mnc001.mcc228.3gppnetwork.org"
+    sar.server_name = "sip:ims.mnc001.mcc228.3gppnetwork.org"
+    sar.server_assignment_type = constants.E_SERVER_ASSIGNMENT_TYPE_ADMINISTRATIVE_DEREGISTRATION
+    sar.user_data_already_available = constants.E_USER_DATA_ALREADY_AVAILABLE_USER_DATA_ALREADY_AVAILABLE
+    sar.scscf_restoration_info = ScscfRestorationInfo(
+        user_name="228011000127286@ims.mnc001.mcc228.3gppnetwork.org",
+        restoration_info=RestorationInfo(
+            path=b"proxy1,proxy2,proxy3",
+            contact=b"<sip:228011000127286@ims.mnc001.mcc228.3gppnetwork.org>",
+            initial_cseq_sequence_number=0,
+            call_id_sip_header=b"",
+            subscription_info=SubscriptionInfo(
+                call_id_sip_header=b"",
+                from_sip_header=b"",
+                to_sip_header=b"",
+                record_route=b"route1,route2,route3",
+                contact=b"<sip:228011000127286@ims.mnc001.mcc228.3gppnetwork.org>",
+            ),
+        ),
+        sip_authentication_scheme=constants.E_SIP_AUTHENTICATION_SCHEME_DIGEST
+    )
+
+    sar.multiple_registration_indication = constants.E_MULTIPLE_REGISTRATION_INDICATION_MULTIPLE_REGISTRATION
+    sar.session_priority = constants.E_SESSION_PRIORITY_PRIORITY_0
+    sar.sar_flags = 0
+    sar.proxy_info = [ProxyInfo(
+        proxy_host=b"swlab.roam.server.net",
+        proxy_state=b"\x00\x00"
+    )]
+    sar.route_record = [b"dra1.route.realm"]
+    msg = sar.as_bytes()
+
+    assert sar.header.length == len(msg)
+    assert sar.header.is_request is True
+
+
+def test_saa_create_new():
+    # build a server-assignment-answer with every attribute populated and
+    # attempt to parse it
+    saa = ServerAssignmentAnswer()
+    saa.session_id = "ims1.epc.mnc001.mcc228.3gppnetwork.org;1744321200;499694;196056826"
+    saa.drmp = constants.E_DRMP_PRIORITY_0
+    saa.vendor_specific_application_id = VendorSpecificApplicationId(
+        vendor_id=constants.VENDOR_TGPP,
+        auth_application_id=constants.APP_3GPP_CX,
+        acct_application_id=constants.APP_3GPP_CX
+    )
+    saa.result_code = constants.E_RESULT_CODE_DIAMETER_SUCCESS
+    saa.experimental_result = ExperimentalResult(
+        vendor_id=constants.VENDOR_TGPP,
+        experimental_result_code=constants.E_RESULT_CODE_DIAMETER_SUCCESS
+    )
+    saa.auth_session_state = constants.E_AUTH_SESSION_STATE_NO_STATE_MAINTAINED
+    saa.origin_host = b"hss1.epc.mnc001.mcc228.3gppnetwork.org"
+    saa.origin_realm = b"epc.mnc001.mcc228.3gppnetwork.org"
+    saa.oc_supported_features = OcSupportedFeatures(
+        oc_feature_vector=0
+    )
+    saa.oc_olr = OcOlr(
+        oc_sequence_number=1,
+        oc_report_type=constants.E_OC_REPORT_TYPE_HOST_REPORT,
+        oc_reduction_percentage=1,
+        oc_validity_duration=1
+    )
+    saa.supported_features = [SupportedFeatures(
+        vendor_id=constants.VENDOR_TGPP,
+        feature_list_id=0,
+        feature_list=1
+    )]
+    saa.user_data = b'<?xml version="1.0" encoding="UTF-8"?><IMSSubscription><PrivateID>228011000127286@ims.mnc001.mcc228.3gppnetwork.org</PrivateID></IMSSubscription>'
+    saa.charging_information = ChargingInformation(
+        primary_event_charging_function_name="aaa://ims.mnc001.mcc228.3gppnetwork.org",
+        secondary_event_charging_function_name="aaa://ims.mnc001.mcc228.3gppnetwork.org",
+        primary_charging_collection_function_name="aaa://ims.mnc001.mcc228.3gppnetwork.org",
+        secondary_charging_collection_function_name="aaa://ims.mnc001.mcc228.3gppnetwork.org",
+    )
+    saa.associated_identities = AssociatedIdentities(
+        user_name=["228011000127286@ims.mnc001.mcc228.3gppnetwork.org"]
+    )
+    saa.loose_route_indication = constants.E_LOOSE_ROUTE_INDICATION_LOOSE_ROUTE_NOT_REQUIRED
+    saa.scscf_restoration_info = [ScscfRestorationInfo(
+        user_name="228011000127286@ims.mnc001.mcc228.3gppnetwork.org",
+        restoration_info=RestorationInfo(
+            path=b"proxy1,proxy2,proxy3",
+            contact=b"<sip:228011000127286@ims.mnc001.mcc228.3gppnetwork.org>",
+            initial_cseq_sequence_number=0,
+            call_id_sip_header=b"",
+            subscription_info=SubscriptionInfo(
+                call_id_sip_header=b"",
+                from_sip_header=b"",
+                to_sip_header=b"",
+                record_route=b"route1,route2,route3",
+                contact=b"<sip:228011000127286@ims.mnc001.mcc228.3gppnetwork.org>",
+            ),
+        ),
+        sip_authentication_scheme=constants.E_SIP_AUTHENTICATION_SCHEME_DIGEST
+    )]
+    saa.associated_registered_identities = AssociatedRegisteredIdentities(
+        user_name=["228011000127286@ims.mnc001.mcc228.3gppnetwork.org"]
+    )
+    saa.server_name = "sip:ims.mnc001.mcc228.3gppnetwork.org"
+    saa.wildcarded_public_identity = "sip:*@ims.mnc001.mcc228.3gppnetwork.org"
+    saa.privileged_sender_indication = constants.E_PRIVILEDGED_SENDER_INDICATION_PRIVILEDGED_SENDER
+    saa.allowed_waf_wwsf_identities = AllowedWafWwsfIdentities(
+        webrtc_authentication_function_name=[""],
+        webrtc_web_server_function_name=[""],
+    )
+    saa.failed_avp = [FailedAvp(additional_avps=[
+        Avp.new(constants.AVP_ORIGIN_HOST, value=b"dra1.local.realm")
+    ])]
+    saa.proxy_info = [ProxyInfo(
+        proxy_host=b"swlab.roam.server.net",
+        proxy_state=b"\x00\x00"
+    )]
+    saa.route_record = [b"dra1.route.realm"]
+
+    msg = saa.as_bytes()
+
+    assert saa.header.length == len(msg)
+    assert saa.header.is_request is False
+
+
+def test_sar_to_saa():
+    req = ServerAssignmentRequest()
+    ans = req.to_answer()
+
+    assert isinstance(ans, ServerAssignmentAnswer)
+    assert ans.header.is_request is False

--- a/tests/test_user_authorization.py
+++ b/tests/test_user_authorization.py
@@ -1,0 +1,119 @@
+"""
+Run from package root:
+~# python3 -m pytest -vv
+"""
+import pytest
+
+from diameter.message import constants
+from diameter.message.avp import Avp
+from diameter.message.commands import UserAuthorizationAnswer, UserAuthorizationRequest
+from diameter.message.commands.user_authorization import ExperimentalResult
+from diameter.message.commands.user_authorization import VendorSpecificApplicationId
+from diameter.message.commands.user_authorization import OcOlr
+from diameter.message.commands.user_authorization import OcSupportedFeatures
+from diameter.message.commands.user_authorization import ServerCapabilities
+from diameter.message.commands.user_authorization import SupportedFeatures
+from diameter.message.commands.user_authorization import ProxyInfo
+from diameter.message.commands.user_authorization import FailedAvp
+
+
+def test_uar_create_new():
+    # build an aa-mobile.node-request with every attribute populated and
+    # attempt to parse it
+    uar = UserAuthorizationRequest()
+
+    uar.vendor_specific_application_id = VendorSpecificApplicationId(
+        vendor_id=constants.VENDOR_TGPP,
+        auth_application_id=constants.APP_3GPP_CX,
+        acct_application_id=constants.APP_3GPP_CX
+    )
+    # TS 29.229 version 13.1.0 Chapter 5.3
+    uar.auth_session_state = constants.E_AUTH_SESSION_STATE_NO_STATE_MAINTAINED
+    uar.origin_host = b"dra1.local.realm"
+    uar.origin_realm = b"epc.local.realm"
+    uar.destination_host = b"hss1.epc.local.realm"
+    uar.destination_realm = b"epc.local.realm"
+    uar.user_name = "228011000127286@ims.mnc001.mcc228.3gppnetwork.org"
+    uar.oc_supported_features = OcSupportedFeatures(
+        oc_feature_vector=0
+    )
+    uar.supported_features = [SupportedFeatures(
+        vendor_id=constants.VENDOR_TGPP,
+        feature_list_id=0,
+        feature_list=1
+    )]
+    uar.public_identity = "sip:228011000127286@ims.mnc001.mcc228.3gppnetwork.org"
+    uar.visited_network_identifier = b"mnc001.mcc228.3gppnetwork.org"
+    uar.user_authorization_type = constants.E_USER_AUTHORIZATION_TYPE_REGISTRATION
+    uar.uar_flags = 0
+    uar.proxy_info = [ProxyInfo(
+        proxy_host=b"swlab.roam.server.net",
+        proxy_state=b"\x00\x00"
+    )]
+    uar.route_record = [b"dra1.route.realm"]
+    msg = uar.as_bytes()
+
+    assert uar.header.length == len(msg)
+    assert uar.header.is_request is True
+
+
+def test_uaa_create_new():
+    # build an aa-mobile-node-answer with every attribute populated and
+    # attempt to parse it
+    uaa = UserAuthorizationAnswer()
+    uaa.session_id = "hss1.epc.local.realm;1;2;3"
+    uaa.drmp = constants.E_DRMP_PRIORITY_0
+    uaa.vendor_specific_application_id = VendorSpecificApplicationId(
+        vendor_id=constants.VENDOR_TGPP,
+        auth_application_id=constants.APP_3GPP_CX,
+        acct_application_id=constants.APP_3GPP_CX
+    )
+    uaa.result_code = constants.E_RESULT_CODE_DIAMETER_SUCCESS
+    uaa.experimental_result = ExperimentalResult(
+        vendor_id=constants.VENDOR_TGPP,
+        experimental_result_code=constants.E_RESULT_CODE_DIAMETER_SUCCESS
+    )
+    uaa.auth_session_state = constants.E_AUTH_SESSION_STATE_NO_STATE_MAINTAINED
+    uaa.origin_host = b"hss1.epc.local.realm"
+    uaa.origin_realm = b"epc.local.realm"
+    uaa.oc_supported_features = OcSupportedFeatures(
+        oc_feature_vector=0
+    )
+    uaa.oc_olr = OcOlr(
+        oc_sequence_number=1,
+        oc_report_type=constants.E_OC_REPORT_TYPE_HOST_REPORT,
+        oc_reduction_percentage=1,
+        oc_validity_duration=1
+    )
+    uaa.supported_features = [SupportedFeatures(
+        vendor_id=constants.VENDOR_TGPP,
+        feature_list_id=0,
+        feature_list=1
+    )]
+    uaa.server_name = "sip:ims.mnc001.mcc228.3gppnetwork.org"
+    uaa.server_capabilities = ServerCapabilities(
+        mandatory_capability=[0],
+        optional_capability=[0],
+        server_name=["sip:ims.mnc001.mcc228.3gppnetwork.org"]
+    )
+    uaa.failed_avp = [FailedAvp(additional_avps=[
+        Avp.new(constants.AVP_ORIGIN_HOST, value=b"dra1.local.realm")
+    ])]
+    uaa.proxy_info = [ProxyInfo(
+        proxy_host=b"swlab.roam.server.net",
+        proxy_state=b"\x00\x00"
+    )]
+    uaa.route_record = [b"dra1.route.realm"]
+
+    msg = uaa.as_bytes()
+
+    assert uaa.header.length == len(msg)
+    assert uaa.header.is_request is False
+
+
+def test_uar_to_uaa():
+    req = UserAuthorizationRequest()
+    ans = req.to_answer()
+
+    assert isinstance(ans, UserAuthorizationAnswer)
+    assert ans.header.is_request is False


### PR DESCRIPTION
Adds Cx/Dx interface implementation from 3GPP TS 29.229, defining commands for:

* User-Authorization (UAR/UAA, 300)
* Server-Assignment (SAR/SAA, 301)
* Location-Info (LIR/LIA, 302)
* Multimedia-Auth (MAR/MAA, 303)
* Registration-Termination (RTR/RTA, 304)
* Push-Profile (PPR/PPA, 305)