### PR TITLE
custom peer selection callback in Node

### DIFF
--- a/docs/guide/application.md
+++ b/docs/guide/application.md
@@ -5,7 +5,7 @@ A diameter application is the highest level of abstraction provided by the
 
  * Synchronous return of answers after sending messages
  * Tracking requests that require answers
- * Routing requests to any suitable peers, including load balancing
+ * Customizable request routing to any suitable peers, including load balancing
  * Constructing answers from received request messages
 
 An "application" is any instance of a subclass of 


### PR DESCRIPTION
Add a new customizable `peer_route_select_func` callback into Node to select from multiple active peers when routing a request. Callback is not invoked when zero or exactly one peer(s) are available.