### PR TITLE
Fix various typos and inconsistencies in documentation

### DIFF
--- a/docs/api/commands/aa.md
+++ b/docs/api/commands/aa.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.aa`.
 
 This module contains AA Request and Answer messages, implementing AVPs
-documented in rfc7155.
+documented in `rfc7155`.
 
 ::: diameter.message.commands.aa.Aa
     options:

--- a/docs/api/commands/accounting.md
+++ b/docs/api/commands/accounting.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.accounting`.
 
 This module contains Accounting Request and Answer messages, implementing
-AVPs documented in rfc6733.
+AVPs documented in `rfc6733`.
 
 ::: diameter.message.commands.accounting.Accounting
     options:

--- a/docs/api/commands/capabilities_exchange.md
+++ b/docs/api/commands/capabilities_exchange.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.capabilities_exchange`.
 
 This module contains Capabilities-Exchange Request and Answer messages, 
-implementing AVPs documented in rfc6733.
+implementing AVPs documented in `rfc6733`.
 
 ::: diameter.message.commands.capabilities_exchange.CapabilitiesExchange
     options:

--- a/docs/api/commands/device_watchdog.md
+++ b/docs/api/commands/device_watchdog.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.device_watchdog`.
 
 This module contains Device Watchdog Request and Answer messages, implementing
-AVPs documented in rfc6733.
+AVPs documented in `rfc6733`.
 
 ::: diameter.message.commands.device_watchdog.DeviceWatchdog
     options:

--- a/docs/api/commands/disconnect_peer.md
+++ b/docs/api/commands/disconnect_peer.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.disconnect_peer`.
 
 This module contains Disconnect-PeerConnection Request and Answer messages, implementing
-AVPs documented in rfc6733.
+AVPs documented in `rfc6733`.
 
 ::: diameter.message.commands.disconnect_peer.DisconnectPeer
     options:

--- a/docs/api/commands/home_agent_mip.md
+++ b/docs/api/commands/home_agent_mip.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.home_agent_mip`.
 
 This module contains Home-Agent-MIP Request and Answer messages, implementing
-AVPs documented in rfc4004.
+AVPs documented in `rfc4004`.
 
 ::: diameter.message.commands.home_agent_mip.HomeAgentMip
     options:

--- a/docs/api/commands/location_info.md
+++ b/docs/api/commands/location_info.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.location_info`.
 
 This module contains Location-Info Request and Answer messages, implementing
-AVPs documented in 3GPP TS 29.229.
+AVPs documented in `3GPP TS 29.229`.
 
 ::: diameter.message.commands.location_info.LocationInfo
     options:

--- a/docs/api/commands/multimedia_auth.md
+++ b/docs/api/commands/multimedia_auth.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.multimedia_auth`.
 
 This module contains Multimedia-Auth Request and Answer messages, implementing
-AVPs documented in 3GPP TS 29.229.
+AVPs documented in `3GPP TS 29.229`.
 
 ::: diameter.message.commands.multimedia_auth.MultimediaAuth
     options:

--- a/docs/api/commands/push_profile.md
+++ b/docs/api/commands/push_profile.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.push_profile`.
 
 This module contains Push-Profile Request and Answer messages, implementing
-AVPs documented in 3GPP TS 29.229.
+AVPs documented in `3GPP TS 29.229`.
 
 ::: diameter.message.commands.push_profile.PushProfile
     options:

--- a/docs/api/commands/re_auth.md
+++ b/docs/api/commands/re_auth.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.re_auth`.
 
 This module contains Re-Auth Request and Answer messages, implementing
-AVPs documented in rfc6733.
+AVPs documented in `rfc6733`.
 
 ::: diameter.message.commands.re_auth.ReAuth
     options:

--- a/docs/api/commands/registration_termination.md
+++ b/docs/api/commands/registration_termination.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.registration_termination`.
 
 This module contains Registration-Termination Request and Answer messages, 
-implementing AVPs documented in 3GPP TS 29.229.
+implementing AVPs documented in `3GPP TS 29.229`.
 
 ::: diameter.message.commands.registration_termination.RegistrationTermination
     options:

--- a/docs/api/commands/server_assignment.md
+++ b/docs/api/commands/server_assignment.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.server_assignment`.
 
 This module contains Server-Assignment Request and Answer messages, 
-implementing AVPs documented in 3GPP TS 29.229.
+implementing AVPs documented in `3GPP TS 29.229`.
 
 ::: diameter.message.commands.server_assignment.ServerAssignment
     options:

--- a/docs/api/commands/session_termination.md
+++ b/docs/api/commands/session_termination.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.session_termination`.
 
 This module contains Session-Termination Request and Answer messages,
-implementing AVPs documented in rfc6733.
+implementing AVPs documented in `rfc6733`.
 
 ::: diameter.message.commands.session_termination.SessionTermination
     options:

--- a/docs/api/commands/spending_limit.md
+++ b/docs/api/commands/spending_limit.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.spending_limit`.
 
 This module contains Spending-Limit Request and Answer messages, 
-implementing AVPs documented in 3GPP TS 29.219.
+implementing AVPs documented in `3GPP TS 29.219`.
 
 ::: diameter.message.commands.spending_limit.SpendingLimit
     options:

--- a/docs/api/commands/spending_status_notification.md
+++ b/docs/api/commands/spending_status_notification.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.spending_status_notification`.
 
 This module contains Spending-Status-Notification Request and Answer messages, 
-implementing AVPs documented in 3GPP TS 29.219.
+implementing AVPs documented in `3GPP TS 29.219`.
 
 ::: diameter.message.commands.spending_status_notification.SpendingStatusNotification
     options:

--- a/docs/api/commands/user_authorization.md
+++ b/docs/api/commands/user_authorization.md
@@ -4,7 +4,7 @@ shallow_toc: 4
 API reference for `diameter.message.commands.user_authorization`.
 
 This module contains User-Authorization Request and Answer messages, 
-implementing AVPs documented in 3GPP TS 29.229.
+implementing AVPs documented in `3GPP TS 29.229`.
 
 ::: diameter.message.commands.user_authorization.UserAuthorization
     options:

--- a/docs/guide/application.md
+++ b/docs/guide/application.md
@@ -61,7 +61,7 @@ The `diameter` package offers three different application implementations:
 [`Application`][diameter.node.application.Application]
 :   The most basic form of an application. Must be subclassed and contains two 
     methods, `handle_request`, which must be overridden, and `handle_answer`,
-    which *may* be overriden, but is usually not necessary. 
+    which *may* be overridden, but is usually not necessary. 
 
     The `Application` class calls internally `handle_request` for each 
     received diameter request in the main thread. It calls `handle_answer` for
@@ -96,7 +96,7 @@ The `diameter` package offers three different application implementations:
 :   A variation of application, which spawns a new thread for each incoming 
     request, up to an optional maximum amount of threads. Must be subclassed.
     Also contains two methods, `handle_request`, which must be overridden, 
-    and `handle_answer`, which *may* be overriden, but is usually not necessary.
+    and `handle_answer`, which *may* be overridden, but is usually not necessary.
 
     Unlike in the base `Application` class, the threading application expects
     that the overridden `handle_request` returns a valid diameter message as an

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -39,7 +39,7 @@ See [working with AVPs](avp.md) for a guide on AVPs.
 # base class for parsing and creating messages
 from diameter.message import Message
 
-# subclasses of messages ae in the `commands` module
+# subclasses of messages are in the `commands` module
 from diameter.message.commands import AbortSessionRequest, ReAuthRequest
 ```
 

--- a/docs/guide/node.md
+++ b/docs/guide/node.md
@@ -64,7 +64,7 @@ persistent will never be automatically connected to. A reconnect attempt is
 [`always_reconnect`][diameter.node.peer.Peer.always_reconnect] attribute to 
 true.
 
-Adding a peer without specifying its ip addresses will only make the peer 
+Adding a peer without specifying its IP addresses will only make the peer 
 "known"; no outgoing connection is ever attempted and the initial connection 
 must be made by the peer themselves, towards our node (for this the node must 
 [act as a server](#starting-a-server)).
@@ -150,7 +150,7 @@ A node has several attributes that can be used or altered after its creation:
     `Node.start()` is called.
 
 `product_name`
-:   The product name that the noed will advertise in CER and CEA. Defaults to 
+:   The product name that the node will advertise in CER and CEA. Defaults to 
     "python-diameter". Can be changed at any time, though preferably before
     `Node.start()` is called.
 

--- a/docs/guide/sample_application.md
+++ b/docs/guide/sample_application.md
@@ -161,7 +161,7 @@ until a given timeout (default 30 seconds) has passed, waiting for an answer to
 arrive through the peer. If an answer is received, it is returned, otherwise an
 exception is raised.
 
-As we are only going to send one single message, the noed can be stopped 
+As we are only going to send one single message, the node can be stopped 
 afterwards, which will cleanly disconnect from the remote peer.
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ AVPs, to communicate with diameter peers using the diameter base protocol and
 to write diameter applications, as defined in the Diameter Base `rfc6733`.
 
 The diameter stack supports transports over both *TCP* and *SCTP*, with 
-SCTP support provided by an optional depency on [pysctp](https://pypi.org/project/pysctp/).
+SCTP support provided by an optional dependency on [pysctp](https://pypi.org/project/pysctp/).
 
 The provided Application and Node implementations handle the majority of the 
 basic protocol-level operations automatically, such as managing peer tables, 
@@ -20,7 +20,7 @@ bytes. Message AVPs can be accessed directly as instance attributes.
 The `diameter` package provides tools for:
 
 - [Parsing and writing AVPs](guide/avp.md)
-- [Parsing and writing diameter Mesages](guide/message.md)
+- [Parsing and writing diameter Messages](guide/message.md)
 - [Creating diameter nodes and connecting to other peers](guide/node.md)
 - [Writing diameter applications](guide/application.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,7 @@ nav:
   - Examples:
     - Credit Control SMS client: examples/credit_control_sms_client.md
     - Idling server and client: examples/idle_server_client.md
-  - API Refrence:
+  - API Reference:
     - AVP:
       - api/avp/index.md
       - Grouped AVPs: api/avp/grouped.md


### PR DESCRIPTION
I'm not sure if typo fix in [`docs/guide/index.md`](https://github.com/mensonen/diameter/pull/29/files#diff-a9f09e5fd39208124b216a0cac772b60ab660bf177b9ecd1ab87f18006cecdbcR42) was entirely correct.