### PR TITLE
user_data correction for Sh interface

### DIFF
--- a/src/diameter/message/commands/profile_update.py
+++ b/src/diameter/message/commands/profile_update.py
@@ -188,7 +188,7 @@ class ProfileUpdateRequest(ProfileUpdate):
         AvpGenDef("wildcarded_impu", AVP_TGPP_WILDCARDED_IMPU, VENDOR_TGPP),
         AvpGenDef("user_name", AVP_USER_NAME),
         AvpGenDef("data_reference", AVP_TGPP_DATA_REFERENCE, VENDOR_TGPP),
-        AvpGenDef("user_data", AVP_TGPP_CX_USER_DATA, VENDOR_TGPP, is_required=True),
+        AvpGenDef("user_data", AVP_TGPP_SH_USER_DATA, VENDOR_TGPP, is_required=True),
         AvpGenDef("oc_supported_features", AVP_OC_SUPPORTED_FEATURES, type_class=OcSupportedFeatures),
         AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
         AvpGenDef("route_record", AVP_ROUTE_RECORD),

--- a/src/diameter/message/commands/push_notification.py
+++ b/src/diameter/message/commands/push_notification.py
@@ -170,7 +170,7 @@ class PushNotificationRequest(PushNotification):
         AvpGenDef("wildcarded_public_identity", AVP_TGPP_WILDCARDED_PSI, VENDOR_TGPP),
         AvpGenDef("wildcarded_impu", AVP_TGPP_WILDCARDED_IMPU, VENDOR_TGPP),
         AvpGenDef("user_name", AVP_USER_NAME),
-        AvpGenDef("user_data", AVP_TGPP_CX_USER_DATA, VENDOR_TGPP, is_required=True),
+        AvpGenDef("user_data", AVP_TGPP_SH_USER_DATA, VENDOR_TGPP, is_required=True),
         AvpGenDef("proxy_info", AVP_PROXY_INFO, type_class=ProxyInfo),
         AvpGenDef("route_record", AVP_ROUTE_RECORD),
     )

--- a/src/diameter/message/commands/subscribe_notifications.py
+++ b/src/diameter/message/commands/subscribe_notifications.py
@@ -127,7 +127,7 @@ class SubscribeNotificationsAnswer(SubscribeNotifications):
         AvpGenDef("wildcarded_public_identity", AVP_TGPP_WILDCARDED_PSI, VENDOR_TGPP),
         AvpGenDef("wildcarded_impu", AVP_TGPP_WILDCARDED_IMPU, VENDOR_TGPP),
         AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
-        AvpGenDef("user_data", AVP_TGPP_CX_USER_DATA, VENDOR_TGPP),
+        AvpGenDef("user_data", AVP_TGPP_SH_USER_DATA, VENDOR_TGPP),
         AvpGenDef("expiry_time", AVP_TGPP_EXPIRY_TIME, VENDOR_TGPP),
         AvpGenDef("oc_supported_features", AVP_OC_SUPPORTED_FEATURES, type_class=OcSupportedFeatures),
         AvpGenDef("oc_olr", AVP_OC_OLR, type_class=OcOlr),

--- a/src/diameter/message/commands/user_data.py
+++ b/src/diameter/message/commands/user_data.py
@@ -124,7 +124,7 @@ class UserDataAnswer(UserData):
         AvpGenDef("supported_features", AVP_TGPP_SUPPORTED_FEATURES, VENDOR_TGPP, type_class=SupportedFeatures),
         AvpGenDef("wildcarded_public_identity", AVP_TGPP_WILDCARDED_PSI, VENDOR_TGPP),
         AvpGenDef("wildcarded_impu", AVP_TGPP_WILDCARDED_IMPU, VENDOR_TGPP),
-        AvpGenDef("user_data", AVP_TGPP_CX_USER_DATA, VENDOR_TGPP),
+        AvpGenDef("user_data", AVP_TGPP_SH_USER_DATA, VENDOR_TGPP),
         AvpGenDef("oc_supported_features", AVP_OC_SUPPORTED_FEATURES, type_class=OcSupportedFeatures),
         AvpGenDef("oc_olr", AVP_OC_OLR, type_class=OcOlr),
         AvpGenDef("load", AVP_LOAD, type_class=Load),


### PR DESCRIPTION
According to the existing code the followings are available:
dictionary.py:
    AVP_TGPP_CX_USER_DATA: {"name": "Cx-User-Data", "type": AvpOctetString, "mandatory": True, "vendor": 10415},
    AVP_TGPP_SH_USER_DATA: {"name": "Sh-User-Data", "type": AvpOctetString, "mandatory": True, "vendor": 10415},

Although the 3GPP standards are referring to these as "User-Data", there are differences in AVP codes:
constants.py
    AVP_TGPP_CX_USER_DATA = 606
    AVP_TGPP_SH_USER_DATA = 702
    
The Sh interface related messages included AVP_TGPP_CX_USER_DATA so these were changed to AVP_TGPP_SH_USER_DATA.

I did not rename the constants or the dictionary elements (although it was suggested) not to break anything, and because this harmonizes with wireshark decodings, and perhaps more user friendly to find, avoids confusion when and where to use it.

After the change this is how a PUR-PUA message sequence looks like:

<img width="1290" height="446" alt="image" src="https://github.com/user-attachments/assets/448d140d-7e64-43ed-8b2b-4cd936411e02" />

The HSS liked it :)